### PR TITLE
Fix `libcudart.so` error in base container

### DIFF
--- a/dockerfiles/starlette/pytorch/Dockerfile.cpu
+++ b/dockerfiles/starlette/pytorch/Dockerfile.cpu
@@ -3,6 +3,7 @@ FROM huggingface/transformers-inference:4.23.1-pt1.11-cpu
 # install starlette framework
 COPY starlette_requirements.txt /tmp/requirements.txt
 RUN pip install  --no-cache-dir -r /tmp/requirements.txt && rm /tmp/requirements.txt
+
 # Think about a better solution -> base contaienr has pt 1.11. thats why need below 0.13
 RUN pip install  --no-cache-dir sentence_transformers torchvision~="0.12.0"
 

--- a/dockerfiles/starlette/pytorch/Dockerfile.gpu
+++ b/dockerfiles/starlette/pytorch/Dockerfile.gpu
@@ -3,6 +3,7 @@ FROM huggingface/transformers-inference:4.23.1-pt1.11-cuda11.5
 # install starlette framework
 COPY starlette_requirements.txt /tmp/requirements.txt
 RUN pip install  --no-cache-dir -r /tmp/requirements.txt && rm /tmp/requirements.txt
+
 # Think about a better solution -> base contaienr has pt 1.11. thats why need below 0.13
 RUN pip install  --no-cache-dir sentence_transformers torchvision~="0.12.0"
 


### PR DESCRIPTION
To be able to use `bitsandbytes` and LLM.int8() we needed to fix a cuda error in the base container
