### PR TITLE
Add `crcmod` to `google` extras

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ extras["test"] = [
 ]
 extras["quality"] = ["isort", "ruff"]
 extras["inf2"] = ["optimum-neuron"]
-extras["google"] = ["google-cloud-storage"]
+extras["google"] = ["google-cloud-storage", "crcmod==1.7"]
 
 setup(
     name="huggingface-inference-toolkit",


### PR DESCRIPTION
## Description

This PR adds `crcmod` as a dependency within the `google` extra of `huggingface-inference-toolkit`, as it's required by `gsutil` when downloading composite objects from Google Cloud Storage (GCS) i.e. useful when downloading large models.