### PR TITLE
pass generator instead of seed to diffusers

### DIFF
--- a/src/huggingface_inference_toolkit/diffusers_utils.py
+++ b/src/huggingface_inference_toolkit/diffusers_utils.py
@@ -47,6 +47,13 @@ class IEAutoPipelineForText2Image:
         prompt,
         **kwargs,
     ):
+        # diffusers doesn't support seed but rather the generator kwarg
+        if "seed" in kwargs:
+            seed = int(kwargs["seed"])
+            generator = torch.Generator().manual_seed(seed)
+            kwargs["generator"] = generator
+            kwargs.pop("seed")
+        
         # TODO: add support for more images (Reason is correct output)
         if "num_images_per_prompt" in kwargs:
             kwargs.pop("num_images_per_prompt")

--- a/src/huggingface_inference_toolkit/diffusers_utils.py
+++ b/src/huggingface_inference_toolkit/diffusers_utils.py
@@ -53,7 +53,7 @@ class IEAutoPipelineForText2Image:
             generator = torch.Generator().manual_seed(seed)
             kwargs["generator"] = generator
             kwargs.pop("seed")
-        
+
         # TODO: add support for more images (Reason is correct output)
         if "num_images_per_prompt" in kwargs:
             kwargs.pop("num_images_per_prompt")


### PR DESCRIPTION
- is seed is passed in
- "convert" to generator which is supported in diffusers
- follows the same logic as in the inference API

Background context: https://huggingface.slack.com/archives/C03E4DQ9LAJ/p1728293731737859