### PR TITLE
Increment Sentence Transformers version to v3.1.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ install_requires = [
 
 extras = {}
 
-extras["st"] = ["sentence_transformers==2.7.0"]
+extras["st"] = ["sentence_transformers==3.1.1"]
 extras["diffusers"] = ["diffusers==0.30.0", "accelerate==0.33.0"]
 # Includes `peft` as PEFT requires `torch` so having `peft` as a core dependency
 # means that `torch` will be installed even if the `torch` extra is not specified.


### PR DESCRIPTION
Hello!

## Pull Request overview
* Increment Sentence Transformers version to v3.1.1

## Details
Version v3.0.1 is required to load models that have Dense modules (https://huggingface.co/sentence-transformers/LaBSE) with Safetensors only. Currently, with v2.7.0, any model with a Dense module that also has Safetensors files, will likely fail in Inference Endpoints.
The reason is that the `pytorch_model.bin` files won't be copied if any `model.safetensors` file is detected, so the Dense module won't be able to load as we need v3.0.1 for that.
See also [this Slack thread](https://huggingface.slack.com/archives/C03E4DQ9LAJ/p1717082696907979) from a while ago for more details.

This is also preventing me from adding Safetensors files to [LaBSE](https://huggingface.co/sentence-transformers/LaBSE).

cc @philschmid 

- Tom Aarsen