### PR TITLE
fix: use exec in endpointry.sh to handle signal correctly via uvicorn

### DIFF
--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -18,4 +18,4 @@ if [[ ! -z "${HF_MODEL_DIR}" ]]; then
 fi
 
 # Start the server
-uvicorn webservice_starlette:app --host 0.0.0.0 --port ${PORT}
+exec uvicorn webservice_starlette:app --host 0.0.0.0 --port ${PORT}


### PR DESCRIPTION
Right now when a pod running this container is deleted a SIGTERM is sent to `entrypoint.sh` which is not forwarded to uvicorn.
There is no graceful shutdown and it will continue to run until a SIGKILL stop it abruptly.