### PR TITLE
Align I/O with Inference API

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 # We don't declare our dependency on transformers here because we build with
 # different packages for different variants
 
-VERSION = "0.5.2"
+VERSION = "0.5.3"
 
 # Ubuntu packages
 # libsndfile1-dev: torchaudio requires the development version of the libsndfile package which can be installed via a system package manager. On Ubuntu it can be installed as follows: apt install libsndfile1-dev

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ VERSION = "0.5.2"
 # libavcodec-extra : libavcodec-extra  includes additional codecs for ffmpeg
 
 install_requires = [
-    "transformers[sklearn,sentencepiece,audio,vision,sentencepiece]==4.46.1",
+    "transformers[sklearn,sentencepiece,audio,vision]==4.46.1",
     "huggingface_hub[hf_transfer]==0.26.2",
     # vision
     "Pillow",

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ VERSION = "0.5.3"
 # libavcodec-extra : libavcodec-extra  includes additional codecs for ffmpeg
 
 install_requires = [
-    "transformers[sklearn,sentencepiece,audio,vision]==4.46.1",
+    "transformers[sklearn,sentencepiece,audio,vision]==4.47.0",
     "huggingface_hub[hf_transfer]==0.26.2",
     # vision
     "Pillow",
@@ -31,11 +31,11 @@ install_requires = [
 
 extras = {}
 
-extras["st"] = ["sentence_transformers==3.2.1"]
-extras["diffusers"] = ["diffusers==0.31.0", "accelerate==1.0.1"]
+extras["st"] = ["sentence_transformers==3.3.1"]
+extras["diffusers"] = ["diffusers==0.31.0", "accelerate==1.1.0"]
 # Includes `peft` as PEFT requires `torch` so having `peft` as a core dependency
 # means that `torch` will be installed even if the `torch` extra is not specified.
-extras["torch"] = ["torch==2.3.1", "torchvision", "torchaudio", "peft==0.13.2"]
+extras["torch"] = ["torch==2.3.1", "torchvision", "torchaudio", "peft==0.14.0"]
 extras["test"] = [
     "pytest==7.2.1",
     "pytest-xdist",

--- a/src/huggingface_inference_toolkit/handler.py
+++ b/src/huggingface_inference_toolkit/handler.py
@@ -68,6 +68,10 @@ class HuggingFaceHandler:
                 parameters["generate_kwargs"] = parameters.pop("generation_parameters")
             if "generate_parameters" in parameters:
                 parameters["generate_kwargs"] = parameters.pop("generate_parameters")
+            generate_kwargs = parameters.pop("generate_kwargs", {})
+            # flatten the values of `generate_kwargs` as it's not supported as is, but via top-level parameters
+            for key, value in generate_kwargs.items():
+                parameters[key] = value
 
         if self.pipeline.task.__contains__("zero-shot-classification"):
             if "candidateLabels" in parameters:

--- a/src/huggingface_inference_toolkit/handler.py
+++ b/src/huggingface_inference_toolkit/handler.py
@@ -62,12 +62,10 @@ class HuggingFaceHandler:
                 )
 
         if self.pipeline.task in {"token-classification", "ner"}:
-            # stride and aggregation_strategy are defined on `pipeline` init, but in the Inference API those
-            # are provided on each request instead
-            for p in {"stride", "aggregation_strategy"}:
-                if p in parameters:
-                    parameters.pop(p)
-                    logger.warning(f"provided parameter `{p}`, but it's not supported.")
+            # even though the parameters `stride`, `aggregation_strategy` and `ignore_labels` are not explicitly
+            # defined within the `transformers.TokenClassificationPipeline.__call__` method, those are indeed
+            # supported and can be used on both the Inferencen API and Inference Endpoints
+            pass
 
         if self.pipeline.task.__contains__("translation"):
             # truncation and generate_parameters are used on Inference API but not available on

--- a/src/huggingface_inference_toolkit/handler.py
+++ b/src/huggingface_inference_toolkit/handler.py
@@ -50,7 +50,7 @@ class HuggingFaceHandler:
             if self.pipeline.task == "table-question-answering":
                 if "question" in inputs:
                     inputs["query"] = inputs.pop("question")
-                if not all(k in inputs for k in {"table", "question"}):
+                if not all(k in inputs for k in {"table", "query"}):
                     raise ValueError(
                         f"{self.pipeline.task} expects `inputs` to contain `table` and either `question` or `query`"
                         " as the input parameters."

--- a/src/huggingface_inference_toolkit/handler.py
+++ b/src/huggingface_inference_toolkit/handler.py
@@ -73,14 +73,16 @@ class HuggingFaceHandler:
                         logger.warning(f"provided parameter `{p}`, but it's not supported.")
 
             if self.pipeline.task.__contains__("zero-shot-classification"):
-                if "candidateLabels" in inputs:
-                    inputs["candidate_labels"] = inputs.pop("candidateLabels")
+                if "candidateLabels" in parameters:
+                    parameters["candidate_labels"] = parameters.pop("candidateLabels")
                 if "text" in inputs:
                     inputs["sequences"] = inputs.pop("text")
-                if not all(k in inputs for k in {"sequences", "candidate_labels"}):
+                if not all(k in inputs for k in {"sequences", "parameters"}) or not all(
+                    k in parameters for k in {"candidate_labels"}
+                ):
                     raise ValueError(
-                        f"{self.pipeline.task} expects `inputs` to contain either `text` or `sequences` and either "
-                        "`candidate_labels` or `candidateLabels`."
+                        f"{self.pipeline.task} expects `inputs` to contain either `text` or `sequences` and "
+                        "`parameters` to contain either `candidate_labels` or `candidateLabels`."
                     )
 
         return (

--- a/src/huggingface_inference_toolkit/handler.py
+++ b/src/huggingface_inference_toolkit/handler.py
@@ -65,12 +65,11 @@ class HuggingFaceHandler:
             "image-to-text",
             "automatic-speech-recognition",
             "text-to-audio",
+            "text-to-speech",
         }:
-            # `generate_kwargs` needs to be a dict, `generation_parameters` or `generate` are not valid names
+            # `generate_kwargs` needs to be a dict, `generation_parameters` is here for forward compatibility
             if "generation_parameters" in parameters:
                 parameters["generate_kwargs"] = parameters.pop("generation_parameters")
-            if "generate" in parameters:
-                parameters["generate_kwargs"] = parameters.pop("generate")
 
         if self.pipeline.task.__contains__("translation") or self.pipeline.task in {"text-generation"}:
             # flatten the values of `generate_kwargs` as it's not supported as is, but via top-level parameters

--- a/src/huggingface_inference_toolkit/handler.py
+++ b/src/huggingface_inference_toolkit/handler.py
@@ -60,16 +60,21 @@ class HuggingFaceHandler:
                     "either `question` or `query`."
                 )
 
-        if self.pipeline.task.__contains__("translation") or self.pipeline.task in {"text-generation"}:
-            # eventually `transformers` will update it to be named `generation_parameters`, in the meantime, in
-            # the current version pinned, it's not supported yet; and is still named `generate_kwargs`
-            # and the Inference API is using `generate_parameters`
+        if self.pipeline.task.__contains__("translation") or self.pipeline.task in {
+            "text-generation",
+            "image-to-text",
+            "automatic-speech-recognition",
+            "text-to-audio",
+        }:
+            # `generate_kwargs` needs to be a dict, `generation_parameters` or `generate` are not valid names
             if "generation_parameters" in parameters:
                 parameters["generate_kwargs"] = parameters.pop("generation_parameters")
-            if "generate_parameters" in parameters:
-                parameters["generate_kwargs"] = parameters.pop("generate_parameters")
-            generate_kwargs = parameters.pop("generate_kwargs", {})
+            if "generate" in parameters:
+                parameters["generate_kwargs"] = parameters.pop("generate")
+
+        if self.pipeline.task.__contains__("translation") or self.pipeline.task in {"text-generation"}:
             # flatten the values of `generate_kwargs` as it's not supported as is, but via top-level parameters
+            generate_kwargs = parameters.pop("generate_kwargs", {})
             for key, value in generate_kwargs.items():
                 parameters[key] = value
 

--- a/src/huggingface_inference_toolkit/handler.py
+++ b/src/huggingface_inference_toolkit/handler.py
@@ -43,17 +43,17 @@ class HuggingFaceHandler:
                 not isinstance(inputs, dict) or not all(k in inputs for k in {"question", "context"})
             ):
                 raise ValueError(
-                    f"{self.pipeline.task} expects `inputs` to contain both `question` and `context` as the keys, "
-                    "both of them being either a `str` or a `List[str]`."
+                    f"{self.pipeline.task} expects `inputs` to be a dict containing both `question` and "
+                    "`context` as the keys, both of them being either a `str` or a `List[str]`."
                 )
 
             if self.pipeline.task == "table-question-answering":
-                if "question" in inputs:
+                if isinstance(inputs, dict) and "question" in inputs:
                     inputs["query"] = inputs.pop("question")
-                if not all(k in inputs for k in {"table", "query"}):
+                if not isinstance(inputs, dict) or not all(k in inputs for k in {"table", "query"}):
                     raise ValueError(
-                        f"{self.pipeline.task} expects `inputs` to contain `table` and either `question` or `query`"
-                        " as the input parameters."
+                        f"{self.pipeline.task} expects `inputs` to be a dict containing the keys `table` and "
+                        "either `question` or `query`."
                     )
 
             if self.pipeline.task in {"token-classification", "ner"}:
@@ -75,14 +75,19 @@ class HuggingFaceHandler:
             if self.pipeline.task.__contains__("zero-shot-classification"):
                 if "candidateLabels" in parameters:
                     parameters["candidate_labels"] = parameters.pop("candidateLabels")
-                if "text" in inputs:
+                if not isinstance(inputs, dict) and (isinstance(inputs, str) or isinstance(inputs, list)):
+                    inputs = {"sequences": inputs}
+                if isinstance(inputs, dict) and "text" in inputs:
                     inputs["sequences"] = inputs.pop("text")
-                if not all(k in inputs for k in {"sequences", "parameters"}) or not all(
-                    k in parameters for k in {"candidate_labels"}
+                if (
+                    not isinstance(inputs, dict)
+                    or not all(k in inputs for k in {"sequences", "parameters"})
+                    or not all(k in parameters for k in {"candidate_labels"})
                 ):
                     raise ValueError(
-                        f"{self.pipeline.task} expects `inputs` to contain either `text` or `sequences` and "
-                        "`parameters` to contain either `candidate_labels` or `candidateLabels`."
+                        f"{self.pipeline.task} expects `inputs` to be a dict containing the key `text` or "
+                        "`sequences`, and `parameters` to be another dict containing either `candidate_labels` "
+                        "or `candidateLabels`."
                     )
 
         return (

--- a/src/huggingface_inference_toolkit/handler.py
+++ b/src/huggingface_inference_toolkit/handler.py
@@ -56,12 +56,19 @@ class HuggingFaceHandler:
             if self.pipeline.task in {"token-classification", "ner"}:
                 # stride and aggregation_strategy are defined on `pipeline` init, but in the Inference API those
                 # are provided on each request instead
-                pass
+                for p in {"stride", "aggregation_strategy"}:
+                    if p in parameters:
+                        parameters.pop(p)
+                        logger.warning(f"provided parameter `{p}`, but it's not supported.")
 
             if self.pipeline.task.__contains__("translation"):
                 # truncation and generate_parameters are used on Inference API but not available on
                 # `TranslationPipeline.__call__` method
-                pass
+                for p in {"truncation", "generate_parameters"}:
+                    if p in parameters:
+                        parameters.pop(p)
+                        logger.warning(f"provided parameter `{p}`, but it's not supported.")
+
 
             if self.pipeline.task.__contains__("zero-shot-classification"):
                 if "candidateLabels" in inputs:

--- a/src/huggingface_inference_toolkit/handler.py
+++ b/src/huggingface_inference_toolkit/handler.py
@@ -116,7 +116,7 @@ class VertexAIHandler(HuggingFaceHandler):
         """
         if "instances" not in data:
             raise ValueError("The request body must contain a key 'instances' with a list of instances.")
-        parameters = data.pop("parameters", None)
+        parameters = data.pop("parameters", {})
 
         predictions = []
         # iterate over all instances and make predictions

--- a/src/huggingface_inference_toolkit/sentence_transformers_utils.py
+++ b/src/huggingface_inference_toolkit/sentence_transformers_utils.py
@@ -39,7 +39,9 @@ class RankingPipeline:
         # `device` needs to be set to "cuda" for GPU
         self.model = CrossEncoder(model_dir, device=device, **kwargs)
 
-    def __call__(self, sentences: Union[List[List[str]], List[Tuple[str, str]]]) -> Dict[str, List[float]]:
+    def __call__(
+        self, sentences: Union[Tuple[str, str], List[str], List[List[str]], List[Tuple[str, str]]]
+    ) -> Dict[str, List[float]]:
         scores = self.model.predict(sentences).tolist()
         return {"scores": scores}
 

--- a/src/huggingface_inference_toolkit/sentence_transformers_utils.py
+++ b/src/huggingface_inference_toolkit/sentence_transformers_utils.py
@@ -1,6 +1,11 @@
 import importlib.util
 from typing import Any, Dict, List, Tuple, Union
 
+try:
+    from typing import Literal
+except ImportError:
+    from typing_extensions import Literal
+
 _sentence_transformers = importlib.util.find_spec("sentence_transformers") is not None
 
 
@@ -45,7 +50,7 @@ class SentenceRankingPipeline:
         query: Union[str, None] = None,
         texts: Union[List[str], None] = None,
         return_documents: bool = False,
-    ) -> Dict[str, List[Any]]:
+    ) -> Union[Dict[str, List[float]], List[Dict[Literal["index", "score", "text"], Any]]]:
         if all(x is not None for x in [sentences, query, texts]):
             raise ValueError(
                 f"The provided payload contains {sentences=} (i.e. 'inputs'), {query=}, and {texts=}"
@@ -73,7 +78,7 @@ class SentenceRankingPipeline:
         # rename "corpus_id" key to "index" for all scores to match TEI
         for score in scores:
             score["index"] = score.pop("corpus_id")  # type: ignore
-        return {"scores": scores}
+        return scores  # type: ignore
 
 
 SENTENCE_TRANSFORMERS_TASKS = {

--- a/src/huggingface_inference_toolkit/sentence_transformers_utils.py
+++ b/src/huggingface_inference_toolkit/sentence_transformers_utils.py
@@ -1,4 +1,5 @@
 import importlib.util
+from typing import Any, Dict, List, Tuple, Union
 
 _sentence_transformers = importlib.util.find_spec("sentence_transformers") is not None
 
@@ -12,33 +13,34 @@ if is_sentence_transformers_available():
 
 
 class SentenceSimilarityPipeline:
-    def __init__(self, model_dir: str, device: str = None, **kwargs):  # needs "cuda" for GPU
+    def __init__(self, model_dir: str, device: Union[str, None] = None, **kwargs: Any) -> None:
+        # `device` needs to be set to "cuda" for GPU
         self.model = SentenceTransformer(model_dir, device=device, **kwargs)
 
-    def __call__(self, inputs=None):
-        embeddings1 = self.model.encode(
-            inputs["source_sentence"], convert_to_tensor=True
-        )
-        embeddings2 = self.model.encode(inputs["sentences"], convert_to_tensor=True)
+    def __call__(self, source_sentence: str, sentences: List[str]) -> Dict[str, float]:
+        embeddings1 = self.model.encode(source_sentence, convert_to_tensor=True)
+        embeddings2 = self.model.encode(sentences, convert_to_tensor=True)
         similarities = util.pytorch_cos_sim(embeddings1, embeddings2).tolist()[0]
         return {"similarities": similarities}
 
 
 class SentenceEmbeddingPipeline:
-    def __init__(self, model_dir: str, device: str = None, **kwargs):  # needs "cuda" for GPU
+    def __init__(self, model_dir: str, device: Union[str, None] = None, **kwargs: Any) -> None:
+        # `device` needs to be set to "cuda" for GPU
         self.model = SentenceTransformer(model_dir, device=device, **kwargs)
 
-    def __call__(self, inputs):
-        embeddings = self.model.encode(inputs).tolist()
+    def __call__(self, sentences: Union[str, List[str]]) -> Dict[str, List[float]]:
+        embeddings = self.model.encode(sentences).tolist()
         return {"embeddings": embeddings}
 
 
 class RankingPipeline:
-    def __init__(self, model_dir: str, device: str = None, **kwargs):  # needs "cuda" for GPU
+    def __init__(self, model_dir: str, device: Union[str, None] = None, **kwargs: Any) -> None:
+        # `device` needs to be set to "cuda" for GPU
         self.model = CrossEncoder(model_dir, device=device, **kwargs)
 
-    def __call__(self, inputs):
-        scores = self.model.predict(inputs).tolist()
+    def __call__(self, sentences: Union[List[List[str]], List[Tuple[str, str]]]) -> Dict[str, List[float]]:
+        scores = self.model.predict(sentences).tolist()
         return {"scores": scores}
 
 
@@ -56,9 +58,5 @@ def get_sentence_transformers_pipeline(task=None, model_dir=None, device=-1, **k
     kwargs.pop("framework", None)
 
     if task not in SENTENCE_TRANSFORMERS_TASKS:
-        raise ValueError(
-            f"Unknown task {task}. Available tasks are: {', '.join(SENTENCE_TRANSFORMERS_TASKS.keys())}"
-        )
-    return SENTENCE_TRANSFORMERS_TASKS[task](
-        model_dir=model_dir, device=device, **kwargs
-    )
+        raise ValueError(f"Unknown task {task}. Available tasks are: {', '.join(SENTENCE_TRANSFORMERS_TASKS.keys())}")
+    return SENTENCE_TRANSFORMERS_TASKS[task](model_dir=model_dir, device=device, **kwargs)

--- a/src/huggingface_inference_toolkit/utils.py
+++ b/src/huggingface_inference_toolkit/utils.py
@@ -208,7 +208,7 @@ def get_device():
 
 
 def get_pipeline(
-    task: str,
+    task: Union[str, None],
     model_dir: Path,
     **kwargs,
 ) -> Pipeline:
@@ -219,12 +219,13 @@ def get_pipeline(
     if is_optimum_neuron_available():
         logger.info("Using device Neuron")
     else:
-        logger.info(f"Using device { 'GPU' if device == 0 else 'CPU'}")
+        logger.info(f"Using device {'GPU' if device == 0 else 'CPU'}")
 
     if task is None:
         raise EnvironmentError(
             "The task for this model is not set: Please set one: https://huggingface.co/docs#how-is-a-models-type-of-inference-api-and-widget-determined"
         )
+
     # define tokenizer or feature extractor as kwargs to load it the pipeline
     # correctly
     if task in {

--- a/tests/unit/test_handler.py
+++ b/tests/unit/test_handler.py
@@ -1,7 +1,7 @@
 import tempfile
+from typing import Dict
 
 import pytest
-from typing import Dict
 from transformers.testing_utils import require_tf, require_torch
 
 from huggingface_inference_toolkit.handler import (
@@ -12,7 +12,6 @@ from huggingface_inference_toolkit.utils import (
     _is_gpu_available,
     _load_repository_from_hf,
 )
-from huggingface_inference_toolkit.logging import logger
 
 TASK = "text-classification"
 MODEL = "hf-internal-testing/tiny-random-distilbert"

--- a/tests/unit/test_sentence_transformers.py
+++ b/tests/unit/test_sentence_transformers.py
@@ -15,9 +15,7 @@ from huggingface_inference_toolkit.utils import (
 @require_torch
 def test_get_sentence_transformers_pipeline():
     with tempfile.TemporaryDirectory() as tmpdirname:
-        storage_dir = _load_repository_from_hf(
-            "sentence-transformers/all-MiniLM-L6-v2", tmpdirname
-        )
+        storage_dir = _load_repository_from_hf("sentence-transformers/all-MiniLM-L6-v2", tmpdirname)
         pipe = get_pipeline("sentence-embeddings", storage_dir.as_posix())
         assert isinstance(pipe, SentenceEmbeddingPipeline)
 
@@ -25,9 +23,7 @@ def test_get_sentence_transformers_pipeline():
 @require_torch
 def test_sentence_embedding_task():
     with tempfile.TemporaryDirectory() as tmpdirname:
-        storage_dir = _load_repository_from_hf(
-            "sentence-transformers/all-MiniLM-L6-v2", tmpdirname
-        )
+        storage_dir = _load_repository_from_hf("sentence-transformers/all-MiniLM-L6-v2", tmpdirname)
         pipe = get_sentence_transformers_pipeline("sentence-embeddings", storage_dir.as_posix())
         res = pipe("Lets create an embedding")
         assert isinstance(res["embeddings"], list)
@@ -36,11 +32,9 @@ def test_sentence_embedding_task():
 @require_torch
 def test_sentence_similarity():
     with tempfile.TemporaryDirectory() as tmpdirname:
-        storage_dir = _load_repository_from_hf(
-            "sentence-transformers/all-MiniLM-L6-v2", tmpdirname
-        )
+        storage_dir = _load_repository_from_hf("sentence-transformers/all-MiniLM-L6-v2", tmpdirname)
         pipe = get_sentence_transformers_pipeline("sentence-similarity", storage_dir.as_posix())
-        res = pipe({"source_sentence": "Lets create an embedding", "sentences": ["Lets create an embedding"]})
+        res = pipe(**{"source_sentence": "Lets create an embedding", "sentences": ["Lets create an embedding"]})
         assert isinstance(res["similarities"], list)
 
 

--- a/tests/unit/test_sentence_transformers.py
+++ b/tests/unit/test_sentence_transformers.py
@@ -1,5 +1,6 @@
 import tempfile
 
+import pytest
 from transformers.testing_utils import require_torch
 
 from huggingface_inference_toolkit.sentence_transformers_utils import (
@@ -25,8 +26,11 @@ def test_sentence_embedding_task():
     with tempfile.TemporaryDirectory() as tmpdirname:
         storage_dir = _load_repository_from_hf("sentence-transformers/all-MiniLM-L6-v2", tmpdirname)
         pipe = get_sentence_transformers_pipeline("sentence-embeddings", storage_dir.as_posix())
-        res = pipe("Lets create an embedding")
+        res = pipe(sentences="Lets create an embedding")
         assert isinstance(res["embeddings"], list)
+        res = pipe(sentences=["Lets create an embedding", "Lets create another embedding"])
+        assert isinstance(res["embeddings"], list)
+        assert len(res["embeddings"]) == 2
 
 
 @require_torch
@@ -34,7 +38,7 @@ def test_sentence_similarity():
     with tempfile.TemporaryDirectory() as tmpdirname:
         storage_dir = _load_repository_from_hf("sentence-transformers/all-MiniLM-L6-v2", tmpdirname)
         pipe = get_sentence_transformers_pipeline("sentence-similarity", storage_dir.as_posix())
-        res = pipe(**{"source_sentence": "Lets create an embedding", "sentences": ["Lets create an embedding"]})
+        res = pipe(source_sentence="Lets create an embedding", sentences=["Lets create an embedding"])
         assert isinstance(res["similarities"], list)
 
 
@@ -44,13 +48,67 @@ def test_sentence_ranking():
         storage_dir = _load_repository_from_hf("cross-encoder/ms-marco-MiniLM-L-6-v2", tmpdirname)
         pipe = get_sentence_transformers_pipeline("sentence-ranking", storage_dir.as_posix())
         res = pipe(
-            [
-                ["Lets create an embedding", "Lets create an embedding"],
-                ["Lets create an embedding", "Lets create an embedding"],
+            sentences=[
+                ["Lets create an embedding", "Lets create another embedding"],
+                ["Lets create an embedding", "Lets create another embedding"],
             ]
         )
         assert isinstance(res["scores"], list)
-        res = pipe(
-            ["Lets create an embedding", "Lets create an embedding"],
-        )
+        res = pipe(sentences=["Lets create an embedding", "Lets create an embedding"])
         assert isinstance(res["scores"], float)
+
+
+@require_torch
+def test_sentence_ranking_tei():
+    with tempfile.TemporaryDirectory() as tmpdirname:
+        storage_dir = _load_repository_from_hf("cross-encoder/ms-marco-MiniLM-L-6-v2", tmpdirname, framework="pytorch")
+        pipe = get_sentence_transformers_pipeline("sentence-ranking", storage_dir.as_posix())
+        res = pipe(
+            query="Lets create an embedding",
+            texts=["Lets create an embedding", "I like noodles"],
+        )
+        assert isinstance(res, list)
+        assert all(r.keys() == {"index", "score"} for r in res)
+
+        res = pipe(
+            query="Lets create an embedding",
+            texts=["Lets create an embedding", "I like noodles"],
+            return_documents=True,
+        )
+        assert isinstance(res, list)
+        assert all(r.keys() == {"index", "score", "text"} for r in res)
+
+
+@require_torch
+def test_sentence_ranking_validation_errors():
+    with tempfile.TemporaryDirectory() as tmpdirname:
+        storage_dir = _load_repository_from_hf("cross-encoder/ms-marco-MiniLM-L-6-v2", tmpdirname, framework="pytorch")
+        pipe = get_sentence_transformers_pipeline("sentence-ranking", storage_dir.as_posix())
+
+        with pytest.raises(
+            ValueError,
+            match=(
+                "you should provide either only 'sentences' i.e. 'inputs' "
+                "of both 'query' and 'texts' to run the ranking task."
+            ),
+        ):
+            pipe(
+                sentences="Lets create an embedding",
+                query="Lets create an embedding",
+                texts=["Lets create an embedding", "I like noodles"],
+            )
+
+        with pytest.raises(
+            ValueError,
+            match=(
+                "No inputs have been provided within the input payload, make sure that the input payload "
+                "contains either 'sentences' i.e. 'inputs', or both 'query' and 'texts'"
+            ),
+        ):
+            pipe(sentences=None, query=None, texts=None)
+
+        with pytest.raises(
+            ValueError,
+            match=("Provided texts=None, but a list of non-empty strings should be provided instead."),
+        ):
+            pipe(sentences=None, query="Lets create an embedding", texts=None)


### PR DESCRIPTION
## Description

This PR aligns the I/O payloads on Inference Endpoints with the definitions for the Inference API, with the I/O payloads currently available via the `transformers.pipeline`, `diffusers.pipeline`, and `sentence-transformer` interfaces.

Additionally, this PR also closes #72 as it includes the handling and validation of both the current `sentence-ranking` approach, as well as the approach compatible with the TEI `/rank` endpoint.