### PR TITLE
Fix `image-text-to-text` provided `kwargs` to skip tokenizer

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,6 +4,12 @@ no_implicit_optional = true
 scripts_are_modules = true
 
 [tool.ruff]
+# Same as Black.
+line-length = 119
+# Assume Python 3.11
+target-version = "py311"
+
+[tool.ruff.lint]
 select = [
     "E", # pycodestyle errors
     "W", # pycodestyle warnings
@@ -17,15 +23,8 @@ ignore = [
     "B008", # do not perform function calls in argument defaults
     "C901", # too complex
 ]
-# Same as Black.
-line-length = 119
-
 # Allow unused variables when underscore-prefixed.
 dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
-
-# Assume Python 3.11
-target-version = "py311"
-
 per-file-ignores = { "__init__.py" = ["F401"] }
 
 [tool.isort]

--- a/src/huggingface_inference_toolkit/utils.py
+++ b/src/huggingface_inference_toolkit/utils.py
@@ -237,7 +237,7 @@ def get_pipeline(
         "zero-shot-image-classification",
     }:
         kwargs["feature_extractor"] = model_dir
-    elif task not in {"image-to-text", "text-to-image"}:
+    elif task not in {"image-text-to-text", "image-to-text", "text-to-image"}:
         kwargs["tokenizer"] = model_dir
 
     if is_sentence_transformers_available() and task in [

--- a/tests/integ/config.py
+++ b/tests/integ/config.py
@@ -16,6 +16,7 @@ from tests.integ.utils import (
     validate_text_to_image,
     validate_translation,
     validate_zero_shot_classification,
+    validate_image_text_to_text,
 )
 
 task2model = {
@@ -108,6 +109,10 @@ task2model = {
         "pytorch": "hf-internal-testing/tiny-random-beit-pipeline",
         "tensorflow": None,
     },
+    "image-text-to-text": {
+        "pytorch": "Salesforce/blip-image-captioning-base",
+        "tensorflow": None,
+    },
 }
 
 
@@ -134,24 +139,12 @@ task2input = {
         "inputs": "question: What is 42 context: 42 is the answer to life, the universe and everything."
     },
     "text-generation": {"inputs": "My name is philipp and I am"},
-    "image-classification": open(
-        os.path.join(os.getcwd(), "tests/resources/image/tiger.jpeg"), "rb"
-    ).read(),
-    "zero-shot-image-classification": open(
-        os.path.join(os.getcwd(), "tests/resources/image/tiger.jpeg"), "rb"
-    ).read(),
-    "object-detection": open(
-        os.path.join(os.getcwd(), "tests/resources/image/tiger.jpeg"), "rb"
-    ).read(),
-    "image-segmentation": open(
-        os.path.join(os.getcwd(), "tests/resources/image/tiger.jpeg"), "rb"
-    ).read(),
-    "automatic-speech-recognition": open(
-        os.path.join(os.getcwd(), "tests/resources/audio/sample1.flac"), "rb"
-    ).read(),
-    "audio-classification": open(
-        os.path.join(os.getcwd(), "tests/resources/audio/sample1.flac"), "rb"
-    ).read(),
+    "image-classification": open(os.path.join(os.getcwd(), "tests/resources/image/tiger.jpeg"), "rb").read(),
+    "zero-shot-image-classification": open(os.path.join(os.getcwd(), "tests/resources/image/tiger.jpeg"), "rb").read(),
+    "object-detection": open(os.path.join(os.getcwd(), "tests/resources/image/tiger.jpeg"), "rb").read(),
+    "image-segmentation": open(os.path.join(os.getcwd(), "tests/resources/image/tiger.jpeg"), "rb").read(),
+    "automatic-speech-recognition": open(os.path.join(os.getcwd(), "tests/resources/audio/sample1.flac"), "rb").read(),
+    "audio-classification": open(os.path.join(os.getcwd(), "tests/resources/audio/sample1.flac"), "rb").read(),
     "table-question-answering": {
         "inputs": {
             "query": "How many stars does the transformers repository have?",
@@ -175,11 +168,15 @@ task2input = {
         }
     },
     "sentence-embeddings": {"inputs": "Lets create an embedding"},
-    "sentence-ranking": {
-        "inputs": ["Lets create an embedding", "Lets create an embedding"]
-    },
+    "sentence-ranking": {"inputs": ["Lets create an embedding", "Lets create an embedding"]},
     "text-to-image": {"inputs": "a man on a horse jumps over a broken down airplane."},
     "custom": {"inputs": "this is a test"},
+    "image-text-to-text": {
+        "inputs": {
+            "images": "https://huggingface.co/datasets/Narsil/image_dummy/raw/main/parrots.png",
+            "text": "A photo of",
+        }
+    },
 }
 
 task2output = {
@@ -213,15 +210,9 @@ task2output = {
         "end": 77,
         "answer": "sagemaker",
     },
-    "summarization": [
-        {"summary_text": " The A The The ANew York City has been installed in the US."}
-    ],
-    "translation_xx_to_yy": [
-        {"translation_text": "Mein Name ist Sarah und ich lebe in London"}
-    ],
-    "text2text-generation": [
-        {"generated_text": "42 is the answer to life, the universe and everything"}
-    ],
+    "summarization": [{"summary_text": " The A The The ANew York City has been installed in the US."}],
+    "translation_xx_to_yy": [{"translation_text": "Mein Name ist Sarah und ich lebe in London"}],
+    "text2text-generation": [{"generated_text": "42 is the answer to life, the universe and everything"}],
     "feature-extraction": None,
     "fill-mask": None,
     "text-generation": None,
@@ -269,6 +260,7 @@ task2output = {
     "sentence-embeddings": {"embeddings": ""},
     "sentence-ranking": {"scores": ""},
     "text-to-image": bytes,
+    "image-text-to-text": [{"input_text": "A photo of", "generated_text": "..."}],
     "custom": {"inputs": "this is a test"},
 }
 
@@ -296,5 +288,6 @@ task2validation = {
     "sentence-embeddings": validate_zero_shot_classification,
     "sentence-ranking": validate_zero_shot_classification,
     "text-to-image": validate_text_to_image,
+    "image-text-to-text": validate_image_text_to_text,
     "custom": validate_custom,
 }

--- a/tests/integ/config.py
+++ b/tests/integ/config.py
@@ -7,6 +7,7 @@ from tests.integ.utils import (
     validate_custom,
     validate_feature_extraction,
     validate_fill_mask,
+    validate_image_text_to_text,
     validate_ner,
     validate_object_detection,
     validate_question_answering,
@@ -16,7 +17,6 @@ from tests.integ.utils import (
     validate_text_to_image,
     validate_translation,
     validate_zero_shot_classification,
-    validate_image_text_to_text,
 )
 
 task2model = {

--- a/tests/integ/utils.py
+++ b/tests/integ/utils.py
@@ -6,6 +6,7 @@ def validate_classification(result=None, snapshot=None):
         assert result[idx].keys() == snapshot[idx].keys()
     return True
 
+
 def validate_conversational(result=None, snapshot=None):
     assert len(result[0]["generated_text"]) >= len(snapshot)
 
@@ -81,6 +82,13 @@ def validate_object_detection(result=None, snapshot=None):
 def validate_text_to_image(result=None, snapshot=None):
     assert isinstance(result, snapshot)
     return True
+
+
+def validate_image_text_to_text(result=None, snapshot=None):
+    assert isinstance(result, list)
+    assert all(isinstance(d, dict) and d.keys() == {"input_text", "generated_text"} for d in result)
+    return True
+
 
 def validate_custom(result=None, snapshot=None):
     logging.info(f"Validate custom task - result: {result}, snapshot: {snapshot}")


### PR DESCRIPTION
## Description

This PR fixes the "image-text-to-text" support as it was including the `tokenizer` as an extra `kwarg` for the `transformers.pipeline` method which is not required as was indeed failing.

Additionally, since this pipeline is recently supported, the unit tests have been included so that this task is also tested to confirm it works.