### PR TITLE
Skip `pipeline.task` check for `diffusers` and `sentence-transformers`

### DIFF
--- a/src/huggingface_inference_toolkit/handler.py
+++ b/src/huggingface_inference_toolkit/handler.py
@@ -36,9 +36,13 @@ class HuggingFaceHandler:
         inputs = data.pop("inputs", data)
         parameters = data.pop("parameters", {})
 
-        # sentence transformers pipelines do not have the `task` arg
-        if any(isinstance(self.pipeline, v) for v in SENTENCE_TRANSFORMERS_TASKS.values()):
-            return self.pipeline(**inputs) if isinstance(inputs, dict) else self.pipeline(inputs)  # type: ignore
+        # diffusers and sentence transformers pipelines do not have the `task` arg
+        if not hasattr(self.pipeline, "task"):
+            return (  # type: ignore
+                self.pipeline(**inputs, **parameters)
+                if isinstance(inputs, dict)
+                else self.pipeline(inputs, **parameters)
+            )
 
         if self.pipeline.task == "question-answering":
             if not isinstance(inputs, dict):

--- a/src/huggingface_inference_toolkit/handler.py
+++ b/src/huggingface_inference_toolkit/handler.py
@@ -3,7 +3,6 @@ from pathlib import Path
 from typing import Any, Dict, Literal, Optional, Union
 
 from huggingface_inference_toolkit.const import HF_TRUST_REMOTE_CODE
-from huggingface_inference_toolkit.sentence_transformers_utils import SENTENCE_TRANSFORMERS_TASKS
 from huggingface_inference_toolkit.utils import (
     check_and_register_custom_pipeline_from_directory,
     get_pipeline,


### PR DESCRIPTION
## Description

This PR solves an issue with the recently included validation for the input payloads, that was leading to conflicts with both the `sentence-transformers` and `diffusers` models since the `task` is not an attribute of the pipeline classes and the validation for those in handled on their respective custom implementations for the `AutoPipelines` i.e. handled separately.

The issue that arised was `{"error":"'IEAutoPipelineForText2Image' object has no attribute 'task'"}`