### PR TITLE
Bump `transformers` and `sentence-transformers`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 # We don't declare our dependency on transformers here because we build with
 # different packages for different variants
 
-VERSION = "0.5.4"
+VERSION = "0.5.5"
 
 # Ubuntu packages
 # libsndfile1-dev: torchaudio requires the development version of the libsndfile package which can be installed via a system package manager. On Ubuntu it can be installed as follows: apt install libsndfile1-dev
@@ -13,8 +13,8 @@ VERSION = "0.5.4"
 # libavcodec-extra : libavcodec-extra  includes additional codecs for ffmpeg
 
 install_requires = [
-    "transformers[sklearn,sentencepiece,audio,vision]==4.48.0",
-    "huggingface_hub[hf_transfer]==0.27.1",
+    "transformers[sklearn,sentencepiece,audio,vision]==4.49.0",
+    "huggingface_hub[hf_transfer]==0.29.2",
     # vision
     "Pillow",
     "librosa",
@@ -31,8 +31,8 @@ install_requires = [
 
 extras = {}
 
-extras["st"] = ["sentence_transformers==3.3.1"]
-extras["diffusers"] = ["diffusers==0.32.1", "accelerate==1.2.1"]
+extras["st"] = ["sentence_transformers==3.4.1"]
+extras["diffusers"] = ["diffusers==0.32.2", "accelerate==1.4.0"]
 # Includes `peft` as PEFT requires `torch` so having `peft` as a core dependency
 # means that `torch` will be installed even if the `torch` extra is not specified.
 extras["torch"] = ["torch==2.3.1", "torchvision", "torchaudio", "peft==0.14.0"]
@@ -57,7 +57,7 @@ setup(
     version=VERSION,
     author="Hugging Face",
     description="Hugging Face Inference Toolkit is for serving 🤗 Transformers models in containers.",
-    url="",
+    url="https://github.com/huggingface/huggingface-inference-toolkit",
     package_dir={"": "src"},
     packages=find_packages(where="src"),
     install_requires=install_requires,

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ install_requires = [
 extras = {}
 
 extras["st"] = ["sentence_transformers==3.4.1"]
-extras["diffusers"] = ["diffusers==0.32.2", "accelerate==1.4.0"]
+extras["diffusers"] = ["diffusers==0.32.1", "accelerate==1.4.0"]
 # Includes `peft` as PEFT requires `torch` so having `peft` as a core dependency
 # means that `torch` will be installed even if the `torch` extra is not specified.
 extras["torch"] = ["torch==2.3.1", "torchvision", "torchaudio", "peft==0.14.0"]

--- a/setup.py
+++ b/setup.py
@@ -16,8 +16,8 @@ install_requires = [
     # Due to an error affecting kenlm and cmake (see https://github.com/kpu/kenlm/pull/464)
     # Also see the transformers patch for it https://github.com/huggingface/transformers/pull/37091
     "kenlm@git+https://github.com/kpu/kenlm@ba83eafdce6553addd885ed3da461bb0d60f8df7",
-    "transformers[sklearn,sentencepiece,audio,vision]==4.48.0",
-    "huggingface_hub[hf_transfer]==0.27.1",
+    "transformers[sklearn,sentencepiece,audio,vision]==4.51.2",
+    "huggingface_hub[hf_transfer]==0.30.2",
     # vision
     "Pillow",
     "librosa",
@@ -34,11 +34,11 @@ install_requires = [
 
 extras = {}
 
-extras["st"] = ["sentence_transformers==3.3.1"]
-extras["diffusers"] = ["diffusers==0.32.1", "accelerate==1.2.1"]
+extras["st"] = ["sentence_transformers==4.0.2"]
+extras["diffusers"] = ["diffusers==0.33.1", "accelerate==1.6.0"]
 # Includes `peft` as PEFT requires `torch` so having `peft` as a core dependency
 # means that `torch` will be installed even if the `torch` extra is not specified.
-extras["torch"] = ["torch==2.3.1", "torchvision", "torchaudio", "peft==0.14.0"]
+extras["torch"] = ["torch==2.5.1", "torchvision", "torchaudio", "peft==0.15.1"]
 extras["test"] = [
     "pytest==7.2.1",
     "pytest-xdist",

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ VERSION = "0.5.5"
 
 install_requires = [
     "transformers[sklearn,sentencepiece,audio,vision]==4.49.0",
-    "huggingface_hub[hf_transfer]==0.29.2",
+    "huggingface_hub[hf_transfer]==0.27.1",
     # vision
     "Pillow",
     "librosa",
@@ -31,8 +31,8 @@ install_requires = [
 
 extras = {}
 
-extras["st"] = ["sentence_transformers==3.4.1"]
-extras["diffusers"] = ["diffusers==0.32.1", "accelerate==1.4.0"]
+extras["st"] = ["sentence_transformers==3.3.1"]
+extras["diffusers"] = ["diffusers==0.32.1", "accelerate==1.2.1"]
 # Includes `peft` as PEFT requires `torch` so having `peft` as a core dependency
 # means that `torch` will be installed even if the `torch` extra is not specified.
 extras["torch"] = ["torch==2.3.1", "torchvision", "torchaudio", "peft==0.14.0"]

--- a/setup.py
+++ b/setup.py
@@ -66,7 +66,7 @@ setup(
     install_requires=install_requires,
     extras_require=extras,
     entry_points={"console_scripts": "serve=sagemaker_huggingface_inference_toolkit.serving:main"},
-    python_requires=">=3.8",
+    python_requires=">=3.9",
     license="Apache License 2.0",
     classifiers=[
         "Development Status :: 5 - Production/Stable",
@@ -76,7 +76,6 @@ setup(
         "License :: OSI Approved :: Apache Software License",
         "Operating System :: OS Independent",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",

--- a/src/huggingface_inference_toolkit/diffusers_utils.py
+++ b/src/huggingface_inference_toolkit/diffusers_utils.py
@@ -73,7 +73,13 @@ class IEAutoPipelineForText2Image:
             logger.warning("The `output_type` cannot be modified, and PIL will be used by default instead.")
 
         # Call pipeline with parameters
-        out = self.pipeline(prompt, num_images_per_prompt=1, **kwargs)
+        if self.pipeline.device.type == "cuda":
+            model_dtype = next(self.pipeline.parameters()).dtype
+            with torch.autocast("cuda", dtype=model_dtype):
+                out = self.pipeline(prompt, num_images_per_prompt=1, **kwargs)
+        else:
+            out = self.pipeline(prompt, num_images_per_prompt=1, **kwargs)
+
         return out.images[0]
 
 

--- a/src/huggingface_inference_toolkit/diffusers_utils.py
+++ b/src/huggingface_inference_toolkit/diffusers_utils.py
@@ -74,8 +74,7 @@ class IEAutoPipelineForText2Image:
 
         # Call pipeline with parameters
         if self.pipeline.device.type == "cuda":
-            model_dtype = next(self.pipeline.parameters()).dtype
-            with torch.autocast("cuda", dtype=model_dtype):
+            with torch.autocast("cuda", dtype=torch.bfloat16):
                 out = self.pipeline(prompt, num_images_per_prompt=1, **kwargs)
         else:
             out = self.pipeline(prompt, num_images_per_prompt=1, **kwargs)

--- a/src/huggingface_inference_toolkit/diffusers_utils.py
+++ b/src/huggingface_inference_toolkit/diffusers_utils.py
@@ -73,11 +73,7 @@ class IEAutoPipelineForText2Image:
             logger.warning("The `output_type` cannot be modified, and PIL will be used by default instead.")
 
         # Call pipeline with parameters
-        if self.pipeline.device.type == "cuda":
-            with torch.autocast("cuda", dtype=torch.bfloat16):
-                out = self.pipeline(prompt, num_images_per_prompt=1, **kwargs)
-        else:
-            out = self.pipeline(prompt, num_images_per_prompt=1, **kwargs)
+        out = self.pipeline(prompt, num_images_per_prompt=1, **kwargs)
 
         return out.images[0]
 

--- a/src/huggingface_inference_toolkit/handler.py
+++ b/src/huggingface_inference_toolkit/handler.py
@@ -50,9 +50,6 @@ class HuggingFaceHandler:
                 else self.pipeline(inputs, **parameters)
             )
 
-        if self.pipeline.task == "automatic-speech-recognition":
-            inputs["input_features"] = inputs.pop("inputs")
-
         if self.pipeline.task == "question-answering":
             if not isinstance(inputs, dict):
                 raise ValueError(f"inputs must be a dict, but a `{type(inputs)}` was provided instead.")

--- a/src/huggingface_inference_toolkit/handler.py
+++ b/src/huggingface_inference_toolkit/handler.py
@@ -50,6 +50,9 @@ class HuggingFaceHandler:
                 else self.pipeline(inputs, **parameters)
             )
 
+        if self.pipeline.task == "automatic-speech-recognition":
+            inputs["input_features"] = inputs.pop("inputs")
+
         if self.pipeline.task == "question-answering":
             if not isinstance(inputs, dict):
                 raise ValueError(f"inputs must be a dict, but a `{type(inputs)}` was provided instead.")


### PR DESCRIPTION
## Description

This PR bumps the versions for `transformers` and `sentence-transformers` in order to support newer architectures enabling serving more models on Inference Endpoints as e.g. Qwen2.5 VL which has been failing lately due to the version not being bumped yet, among others.

Both `accelerate` and `diffusers` haven't been bumped in the end, as there were a lot of arising issues as of the update of those at the moment as spotted by @ErikKaum.