### PR TITLE
Attempt hf login if token provided

### DIFF
--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -22,6 +22,13 @@ if [[ ! -z "${HF_MODEL_ID}" ]]; then
     filename=${HF_DEFAULT_PIPELINE_NAME:-handler.py}
     revision=${HF_REVISION:-main}
 
+    if [[ ! -z "${HF_HUB_TOKEN}" ]]; then
+        echo "Attempting HuggingFace CLI login"
+        huggingface-cli login --token $HF_HUB_TOKEN
+    else
+        echo "HF_HUB_TOKEN not provided"
+    fi
+
     echo "Downloading $filename for model ${HF_MODEL_ID}"
     huggingface-cli download ${HF_MODEL_ID} "$filename" --revision "$revision" --local-dir /tmp
 


### PR DESCRIPTION
Many enterprises will deploy their models from private repositories. Currently, this image will fail to load them. 

This change attempts to log in to HuggingFace `$HF_HUB_TOKEN` is provided, allowing deployments from private repositories.