### PR TITLE
Rename `text-ranking` to former `sentence-ranking`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 # We don't declare our dependency on transformers here because we build with
 # different packages for different variants
 
-VERSION = "0.5.5"
+VERSION = "0.5.6"
 
 # Ubuntu packages
 # libsndfile1-dev: torchaudio requires the development version of the libsndfile package which can be installed via a system package manager. On Ubuntu it can be installed as follows: apt install libsndfile1-dev

--- a/src/huggingface_inference_toolkit/utils.py
+++ b/src/huggingface_inference_toolkit/utils.py
@@ -134,7 +134,7 @@ def _load_repository_from_hf(
 
     # create regex to only include the framework specific weights
     ignore_regex = create_artifact_filter(framework)
-    logger.info(f"Ignore regex pattern for files, which are not downloaded: { ', '.join(ignore_regex) }")
+    logger.info(f"Ignore regex pattern for files, which are not downloaded: {', '.join(ignore_regex)}")
 
     # Download the repository to the workdir and filter out non-framework
     # specific weights
@@ -244,7 +244,10 @@ def get_pipeline(
         "sentence-similarity",
         "sentence-embeddings",
         "sentence-ranking",
+        "text-ranking",
     ]:
+        if task == "text-ranking":
+            task = "sentence-ranking"
         hf_pipeline = get_sentence_transformers_pipeline(task=task, model_dir=model_dir, device=device, **kwargs)
     elif is_diffusers_available() and task == "text-to-image":
         hf_pipeline = get_diffusers_pipeline(task=task, model_dir=model_dir, device=device, **kwargs)


### PR DESCRIPTION
## Description

This PR applies a rename when the task is set to `text-ranking` as it was formerly named `sentence-ranking`, but since it's officially named now "Text Ranking" in the Hub as per https://huggingface.co/tasks/text-ranking, the rename is required so that the former `sentence-ranking` pipeline is used.

cc @ErikKaum