### PR TITLE
🔒 Pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/docker-build-action.yaml
+++ b/.github/workflows/docker-build-action.yaml
@@ -32,25 +32,25 @@ jobs:
       group: aws-highmemory-32-plus-priv
     steps:
       - name: Check out
-        uses: actions/checkout@v3
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2.0.0
+        uses: docker/setup-buildx-action@dc7b9719a96d48369863986a06765841d7ea23f6  # v2.0.0
         with:
           install: true
 
       - name: Login to container registry
-        uses: docker/login-action@v2.0.0
+        uses: docker/login-action@49ed152c8eca782a232dede0303416e8f356c37b  # v2.0.0
         with:
           registry: ${{ inputs.repository }}
           username: ${{ secrets.REGISTRY_USERNAME }}
           password: ${{ secrets.REGISTRY_PASSWORD }}
 
       - name: Inject slug/short variables
-        uses: rlespinasse/github-slug-action@v4
+        uses: rlespinasse/github-slug-action@797d68864753cbceedc271349d402da4590e6302  # v4
 
       - name: Build and push image to container registry
-        uses: docker/build-push-action@v3.0.0
+        uses: docker/build-push-action@e551b19e49efd4e98792db7592c17c09b89db8d8  # v3.0.0
         with:
           push: true
           context: ${{ inputs.context }}

--- a/.github/workflows/integration-test-action.yaml
+++ b/.github/workflows/integration-test-action.yaml
@@ -51,13 +51,13 @@ jobs:
       HF_HUB_CACHE: ${{ inputs.hf_hub_cache }}
       RUN_SLOW: ${{ inputs.run_slow }}
     steps:
-    - uses: actions/checkout@v4.1.1
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
     - name: Docker Setup Buildx
-      uses: docker/setup-buildx-action@v3.0.0
+      uses: docker/setup-buildx-action@f95db51fddba0c2d1ec667646a06c2ce06100226  # v3.0.0
     - name: Docker Build
       run: ${{ inputs.build_img_cmd }}
     - name: Set up Python 3.11
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@e9aba2c848f5ebd159c070c61ea2c4e2b122355e  # v2
       with:
         python-version: 3.11
     - name: Install dependencies


### PR DESCRIPTION
## 🔒 Pin GitHub Actions to commit SHAs

This PR pins all GitHub Actions to their exact commit SHA instead of mutable tags or branch names.

**Why?**
Pinning to a SHA prevents supply chain attacks where a tag (e.g. `v4`) could be moved to point to malicious code.

### Changes

| Workflow | Action | Avant | Après | SHA |
|---|---|---|---|---|
| `docker-build-action.yaml` | `actions/checkout` | `v3` | `v6.0.2` | `de0fac2e4500…` |
| `docker-build-action.yaml` | `docker/setup-buildx-action` | `v2.0.0` | `v2.0.0` | `dc7b9719a96d…` |
| `docker-build-action.yaml` | `docker/login-action` | `v2.0.0` | `v2.0.0` | `49ed152c8eca…` |
| `docker-build-action.yaml` | `rlespinasse/github-slug-action` | `v4` | `v4` | `797d68864753…` |
| `docker-build-action.yaml` | `docker/build-push-action` | `v3.0.0` | `v3.0.0` | `e551b19e49ef…` |
| `integration-test-action.yaml` | `actions/checkout` | `v4.1.1` | `v6.0.2` | `de0fac2e4500…` |
| `integration-test-action.yaml` | `docker/setup-buildx-action` | `v3.0.0` | `v3.0.0` | `f95db51fddba…` |
| `integration-test-action.yaml` | `actions/setup-python` | `v2` | `v2` | `e9aba2c848f5…` |

> 🤖 Generated by `/github-actions-audit` — [security/pin-actions-to-sha]


Closes huggingface/tracking-issues#143