### PR TITLE
fix(deps): pin starlette>=1.0.1 to address GHSA-86qp-5c8j-p5mr

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,9 @@ install_requires = [
     "phonemizer",
     "ffmpeg",
     # web api
-    "starlette",
+    # Pin >= 1.0.1 to address CVE-2026-48710 (GHSA-86qp-5c8j-p5mr):
+    # Host header poisons request.url.path; path-based middleware can be bypassed.
+    "starlette>=1.0.1",
     "uvicorn",
     "pandas",
     "orjson",

--- a/src/huggingface_inference_toolkit/webservice_starlette.py
+++ b/src/huggingface_inference_toolkit/webservice_starlette.py
@@ -1,5 +1,6 @@
 import base64
 import os
+from contextlib import asynccontextmanager
 from pathlib import Path
 from time import perf_counter
 
@@ -64,6 +65,15 @@ async def prepare_model_artifacts():
         HF_MODEL_DIR, task=HF_TASK
     )
     logger.info("Model initialized successfully")
+
+
+@asynccontextmanager
+async def lifespan(app):
+    # Starlette 1.0 removed `on_startup` / `on_shutdown` in favor of the
+    # ASGI lifespan protocol. We run the model-artifact preparation once at
+    # startup; there is no per-process shutdown work to do.
+    await prepare_model_artifacts()
+    yield
 
 
 async def health(request):
@@ -156,7 +166,7 @@ if os.getenv("AIP_MODE", None) == "PREDICTION":
             Route(_health_route, health, methods=["GET"]),
             Route(_predict_route, predict, methods=["POST"]),
         ],
-        on_startup=[prepare_model_artifacts],
+        lifespan=lifespan,
     )
 else:
     app = Starlette(
@@ -168,5 +178,5 @@ else:
             Route("/predict", predict, methods=["POST"]),
             Route("/metrics", metrics, methods=["GET"]),
         ],
-        on_startup=[prepare_model_artifacts],
+        lifespan=lifespan,
     )


### PR DESCRIPTION
## Summary

Pin `starlette>=1.0.1` in `setup.py` to address [GHSA-86qp-5c8j-p5mr](https://github.com/encode/starlette/security/advisories/GHSA-86qp-5c8j-p5mr) (CVE-2026-48710).

Starlette `<= 1.0.0` reconstructs `request.url` from `http://{Host}{path}` without validating the Host header. An attacker sending `Host: example.com/abc?bar=` makes `request.url.path` resolve to `/abc` while the router still dispatches to the real `/foo`. Middleware that gates on `request.url.path` can be bypassed.

## SDK exposure assessment

This toolkit uses `request.url.path` in `src/huggingface_inference_toolkit/webservice_starlette.py` **only for logging the request duration** (`logger.info(f"POST {request.url.path} | Duration: ...")`). It is not used for auth/authz decisions, so the worst-case impact in this codebase is a corrupted log line under Host header manipulation, not auth bypass.

The pin is applied as a **preventive** measure (defense in depth) and to drag in the fixed framework version on any fresh resolve. The previous declaration (`"starlette"` with no constraint) accepts the vulnerable range.

## Changes

- `setup.py`: `"starlette"` -> `"starlette>=1.0.1"` (+ comment referencing the advisory)

No code changes. No lockfile changes (this repo doesn't ship a lockfile).

## Test plan

- [ ] CI passes (pre-commit + any pytest jobs)
- [ ] Local: `pip install -e .` and import `huggingface_inference_toolkit`, confirm no resolution error
- [ ] Manual smoke if available: spin up the inference toolkit webservice and hit a known endpoint, confirm responses

## Why now

Org-wide audit for GHSA-86qp-5c8j-p5mr surfaced this repo. Tracking PR for the SDK side already merged in `huggingface/hf-inference-sdk#70`.