### PR TITLE
fix(ci): stop the test jobs depending on the runner's shared /mnt/hf_cache

### DIFF
--- a/.github/workflows/integration-test-action.yaml
+++ b/.github/workflows/integration-test-action.yaml
@@ -5,14 +5,6 @@ on:
         type: string
         required: false
         default: "us-east-1"
-      hf_home:
-        required: false
-        type: string
-        default: "/mnt/hf_cache/"
-      hf_hub_cache:
-        required: false
-        type: string
-        default: "/mnt/hf_cache/hub"
       run_slow:
         required: false
         type: string
@@ -47,8 +39,13 @@ jobs:
       group: ${{ inputs.runs_on }}
     env:
       AWS_REGION: ${{ inputs.region }}
-      HF_HOME: ${{ inputs.hf_home }}
-      HF_HUB_CACHE: ${{ inputs.hf_hub_cache }}
+      # Keep the model cache inside the job's own workspace, so a run never depends on state
+      # shared with anything else. Models are re-downloaded every run; the integ test fixtures
+      # are tiny on purpose. It has to be the workspace rather than somewhere under $HOME
+      # because conftest bind-mounts the downloaded model dir into the test container, so the
+      # docker daemon has to be able to resolve the path as well.
+      HF_HOME: ${{ github.workspace }}/.hf_cache
+      HF_HUB_CACHE: ${{ github.workspace }}/.hf_cache/hub
       RUN_SLOW: ${{ inputs.run_slow }}
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2

--- a/.github/workflows/integration-test-action.yaml
+++ b/.github/workflows/integration-test-action.yaml
@@ -39,13 +39,15 @@ jobs:
       group: ${{ inputs.runs_on }}
     env:
       AWS_REGION: ${{ inputs.region }}
-      # Keep the model cache inside the job's own workspace, so a run never depends on state
-      # shared with anything else. Models are re-downloaded every run; the integ test fixtures
-      # are tiny on purpose. It has to be the workspace rather than somewhere under $HOME
-      # because conftest bind-mounts the downloaded model dir into the test container, so the
-      # docker daemon has to be able to resolve the path as well.
-      HF_HOME: ${{ github.workspace }}/.hf_cache
-      HF_HUB_CACHE: ${{ github.workspace }}/.hf_cache/hub
+      # Keep the model cache in the job's own scratch dir, so a run never depends on cache state
+      # it does not own. runner.temp is emptied by the runner at the start and end of every job,
+      # unlike $HOME, which on these long-lived self-hosted runners survives across jobs and would
+      # reintroduce exactly the shared state we are removing here.
+      # It also has to stay a real path on the runner host: conftest hands the downloaded model dir
+      # straight to `docker run -v`, so the docker daemon has to resolve it, not just pytest.
+      # Models are re-downloaded every run; the integ fixtures are tiny on purpose.
+      HF_HOME: ${{ runner.temp }}/hf_cache
+      HF_HUB_CACHE: ${{ runner.temp }}/hf_cache/hub
       RUN_SLOW: ${{ inputs.run_slow }}
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2

--- a/.github/workflows/unit-test.yaml
+++ b/.github/workflows/unit-test.yaml
@@ -23,16 +23,12 @@ jobs:
       group: aws-g4dn-2xlarge-cache
     env:
       AWS_REGION: us-east-1
-      CACHE_TEST_DIR: /mnt/hf_cache/hf-inference-toolkit-tests
+      # Only ever used as a bind-mount target inside the test container, so it does not need
+      # to point anywhere outside the job.
+      CACHE_TEST_DIR: /opt/hf-inference-toolkit-tests
       RUN_SLOW: True
     steps:
     - uses: actions/checkout@v4.1.1
-    - name: Copy unit tests to cache mount
-      run: |
-        sudo rm -rf ${{ env.CACHE_TEST_DIR }} && \
-        sudo mkdir ${{ env.CACHE_TEST_DIR }} && \
-        sudo chown -R runner ${{ env.CACHE_TEST_DIR }}
-        cp -r tests ${{ env.CACHE_TEST_DIR }}
     - name: Docker Setup Buildx
       uses: docker/setup-buildx-action@v3.0.0
     - name: Docker Build


### PR DESCRIPTION
Both test workflows point at `/mnt/hf_cache`, a path on the self-hosted runners that the jobs do not own. A run's outcome then depends on state it did not create, and breaks whenever that mount is missing or its permissions change.

**`unit-test.yaml`** — the "Copy unit tests to cache mount" step was vestigial: it copied the tests to `$CACHE_TEST_DIR/tests`, while the container is started with `-v ./tests:$CACHE_TEST_DIR` and runs `pytest $CACHE_TEST_DIR/unit` — so it always read the checkout, never the copy, whose layout would not even have matched. The step is dropped and `CACHE_TEST_DIR` now points at a job-local path: it is only ever a bind-mount target inside the test container, which docker creates on its own.

**`integration-test-action.yaml`** — `HF_HOME` / `HF_HUB_CACHE` now live under `${{ runner.temp }}/hf_cache`, which the runner empties at the start and end of every job. `$HOME` would not do: on these long-lived self-hosted runners it survives across jobs, which is the shared state this PR is removing. The path does have to stay a real path on the runner host, because `tests/integ/conftest.py` hands the downloaded model dir straight to `docker run -v` and the docker daemon has to resolve it too — but the job runs directly on the host (no `container:`), so that is not a constraint on *where* under the host it lives. Models are re-downloaded every run; the integ fixtures are tiny on purpose. The `hf_home` / `hf_hub_cache` inputs are dropped: no caller passes them.

CI-only, no runtime change. First step of the progressive port of `api-inference-mini-fork` onto `main`.