### PR TITLE
feat: tolerate real-world Content-Type and Accept headers

### DIFF
--- a/src/huggingface_inference_toolkit/serialization/base.py
+++ b/src/huggingface_inference_toolkit/serialization/base.py
@@ -1,12 +1,11 @@
+from typing import Optional
+
 from huggingface_inference_toolkit.serialization.audio_utils import Audioer
 from huggingface_inference_toolkit.serialization.image_utils import Imager
 from huggingface_inference_toolkit.serialization.json_utils import Jsoner
 
 content_type_mapping = {
     "application/json": Jsoner,
-    "application/json; charset=UTF-8": Jsoner,
-    "text/csv": None,
-    "text/plain": None,
     # image types
     "image/png": Imager,
     "image/jpeg": Imager,
@@ -37,11 +36,43 @@ content_type_mapping = {
 }
 
 
+def _normalize(media_type: str) -> str:
+    """Strip any parameter (charset, codecs, ...) and fold case: `image/PNG; foo=bar` -> `image/png`."""
+    return media_type.split(";")[0].strip().lower()
+
+
+# Media types are matched case-insensitively and without their parameters, hence a lookup keyed on
+# the normalized form of every supported type. `content_type_mapping` stays the documented list
+# and is what error messages report.
+_normalized_mapping = {_normalize(media_type): serializer for media_type, serializer in content_type_mapping.items()}
+
+
 class ContentType:
     @staticmethod
-    def get_deserializer(content_type):
-        if content_type in content_type_mapping:
-            return content_type_mapping[content_type]
+    def get_deserializer(content_type: str, task: Optional[str]):
+        if not content_type:
+            message = "No content type provided and no default one configured."
+            raise Exception(message)
+
+        media_type = _normalize(content_type)
+
+        if media_type == "application/octet-stream":
+            # Raw bytes announce nothing about their own type, so the task has to decide how to
+            # read them.
+            if task:
+                if "audio" in task or "speech" in task:
+                    return Audioer
+                if "image" in task:
+                    return Imager
+            message = f"""
+                Content type "{content_type}" not supported for task {task}.
+                Supported content types are:
+                {", ".join(list(content_type_mapping.keys()))}
+            """
+            raise Exception(message)
+
+        if media_type in _normalized_mapping:
+            return _normalized_mapping[media_type]
         else:
             message = f"""
                 Content type "{content_type}" not supported.
@@ -51,13 +82,23 @@ class ContentType:
             raise Exception(message)
 
     @staticmethod
-    def get_serializer(accept):
-        if accept in content_type_mapping:
-            return content_type_mapping[accept]
-        else:
-            message = f"""
-                Accept type "{accept}" not supported.
-                Supported accept types are:
-                {", ".join(list(content_type_mapping.keys()))}
-            """
-            raise Exception(message)
+    def resolve_accept(accept: str) -> str:
+        """
+        Resolve an Accept header to the media type we will answer with: the first entry we can
+        actually produce, normalized. Callers must serialize and label the response with this
+        rather than with the raw header, which may list several types and carry parameters.
+        """
+        for candidate in accept.split(","):
+            media_type = _normalize(candidate)
+            if media_type in _normalized_mapping:
+                return media_type
+        message = f"""
+            Accept type "{accept}" not supported.
+            Supported accept types are:
+            {", ".join(list(content_type_mapping.keys()))}
+        """
+        raise Exception(message)
+
+    @staticmethod
+    def get_serializer(accept: str):
+        return _normalized_mapping[ContentType.resolve_accept(accept)]

--- a/src/huggingface_inference_toolkit/webservice_starlette.py
+++ b/src/huggingface_inference_toolkit/webservice_starlette.py
@@ -97,9 +97,9 @@ async def metrics(request):
 async def predict(request):
     try:
         # extracts content from request
-        content_type = request.headers.get("content-Type", None)
+        content_type = request.headers.get("content-Type", os.environ.get("DEFAULT_CONTENT_TYPE", ""))
         # try to deserialize payload
-        deserialized_body = ContentType.get_deserializer(content_type).deserialize(
+        deserialized_body = ContentType.get_deserializer(content_type, HF_TASK).deserialize(
             await request.body()
         )
         # checks if input schema is correct
@@ -145,7 +145,10 @@ async def predict(request):
         # response extracts content from request
         accept = request.headers.get("accept", None)
         if accept is None or accept == "*/*":
-            accept = "application/json"
+            accept = os.environ.get("DEFAULT_ACCEPT", "application/json")
+        # An Accept header may list several types and carry parameters: resolve it to the single
+        # media type we answer with, and serialize / label the response with that one.
+        accept = ContentType.resolve_accept(accept)
         # deserialized and resonds with json
         serialized_response_body = ContentType.get_serializer(accept).serialize(
             pred, accept

--- a/tests/unit/test_serialization.py
+++ b/tests/unit/test_serialization.py
@@ -1,0 +1,100 @@
+import pytest
+
+from huggingface_inference_toolkit.serialization.audio_utils import Audioer
+from huggingface_inference_toolkit.serialization.base import ContentType
+from huggingface_inference_toolkit.serialization.image_utils import Imager
+from huggingface_inference_toolkit.serialization.json_utils import Jsoner
+
+
+@pytest.mark.parametrize(
+    "content_type,expected",
+    [
+        ("application/json", Jsoner),
+        # parameters are not part of the media type
+        ("application/json; charset=UTF-8", Jsoner),
+        ("application/json;charset=utf-8", Jsoner),
+        ("image/png", Imager),
+        ("audio/wav", Audioer),
+        # both the mapping and the header may carry case
+        ("APPLICATION/JSON", Jsoner),
+        ("audio/AMR-WB", Audioer),
+        ("audio/amr-wb", Audioer),
+        ("audio/webm;codecs=opus", Audioer),
+    ],
+)
+def test_get_deserializer_media_types(content_type, expected):
+    assert ContentType.get_deserializer(content_type, "text-classification") is expected
+
+
+@pytest.mark.parametrize(
+    "task,expected",
+    [
+        ("automatic-speech-recognition", Audioer),
+        ("audio-classification", Audioer),
+        ("image-classification", Imager),
+        ("image-segmentation", Imager),
+    ],
+)
+def test_get_deserializer_octet_stream_resolves_by_task(task, expected):
+    # Raw bytes say nothing about their own type, so the task decides
+    assert ContentType.get_deserializer("application/octet-stream", task) is expected
+    assert ContentType.get_deserializer("Application/Octet-Stream", task) is expected
+
+
+@pytest.mark.parametrize("task", ["text-classification", None, ""])
+def test_get_deserializer_octet_stream_rejected_for_other_tasks(task):
+    with pytest.raises(Exception, match="not supported for task"):
+        ContentType.get_deserializer("application/octet-stream", task)
+
+
+def test_get_deserializer_requires_a_content_type():
+    with pytest.raises(Exception, match="No content type provided"):
+        ContentType.get_deserializer("", "text-classification")
+    with pytest.raises(Exception, match="No content type provided"):
+        ContentType.get_deserializer(None, "text-classification")
+
+
+@pytest.mark.parametrize("content_type", ["text/plain", "text/csv", "application/xml"])
+def test_get_deserializer_rejects_unsupported_types(content_type):
+    with pytest.raises(Exception, match="not supported"):
+        ContentType.get_deserializer(content_type, "text-classification")
+
+
+@pytest.mark.parametrize(
+    "accept,expected",
+    [
+        ("application/json", Jsoner),
+        ("image/png", Imager),
+        ("application/json; charset=UTF-8", Jsoner),
+        # first supported type in the list wins
+        ("text/html, application/json", Jsoner),
+        ("text/html;q=0.9, image/png;q=0.8", Imager),
+    ],
+)
+def test_get_serializer_accept_lists(accept, expected):
+    assert ContentType.get_serializer(accept) is expected
+
+
+def test_get_serializer_rejects_when_nothing_is_producible():
+    with pytest.raises(Exception, match="not supported"):
+        ContentType.get_serializer("text/html, application/xml")
+
+
+@pytest.mark.parametrize(
+    "accept,expected",
+    [
+        ("application/json", "application/json"),
+        ("image/PNG", "image/png"),
+        ("image/png;q=0.8", "image/png"),
+        ("text/html;q=0.9, image/png;q=0.8", "image/png"),
+    ],
+)
+def test_resolve_accept_returns_a_bare_media_type(accept, expected):
+    # Imager.serialize derives the image format from this value and it also labels the response,
+    # so it must never carry the parameters or the other entries of the header
+    assert ContentType.resolve_accept(accept) == expected
+
+
+def test_resolve_accept_rejects_when_nothing_is_producible():
+    with pytest.raises(Exception, match="not supported"):
+        ContentType.resolve_accept("text/html")


### PR DESCRIPTION
> **Stacked on #127** (which is itself stacked on #126). Base is `feat/discard-left` because this PR edits `predict()` a few lines from where #127 inserts its 204 check. GitHub retargets automatically as each parent merges; review the single commit above the base.

Third step of the progressive port of `api-inference-mini-fork` onto `main`, sourced from `46fa298` (last fork commit before the transformers 5.x bump). Skipping the latency guard for now, per your call.

## What was wrong

Both headers were matched by exact string equality against `content_type_mapping`, so a request was only servable if its header happened to be spelled exactly like a key:

- `Content-Type: application/json; charset=utf-8` worked only because that exact spelling was hardcoded as a second key — `application/json;charset=utf-8` (no space) did not.
- `Accept: text/html, application/json` was rejected outright even though we can serve the second entry. Browsers and proxies routinely send lists with q-values.
- `application/octet-stream` was unsupported, so posting raw audio or image bytes without a specific media type returned 400.

## What changes

Media types are matched with parameters stripped and case folded **on both sides**: `_normalized_mapping` is derived from `content_type_mapping`, which stays the documented list and the one error messages report. `Accept` is walked entry by entry, first producible type wins. `application/octet-stream` resolves via the task — audio/speech tasks read it as audio, image tasks as an image, anything else stays an error.

`DEFAULT_CONTENT_TYPE` and `DEFAULT_ACCEPT` come along, both inert unless set.

`text/csv` and `text/plain` are dropped from the mapping. They mapped to `None`, so they never served those requests — they crashed on `None.deserialize(...)` and returned a 400 reading `'NoneType' object has no attribute 'deserialize'`. They now get the regular "not supported" message.

## Two fixes on top of the fork

Worth a look, since these are deliberate divergences:

1. **The fork breaks `audio/AMR-WB`.** It lowercases the Content-Type header while the mapping keeps case-sensitive keys; `audio/AMR-WB` and `audio/AMR-WB+` have no lowercase twin (unlike `audio/AMR`, which does), so they would start returning 400 — they work on main today. Normalizing both sides keeps them working, and additionally makes `audio/amr-wb` work, which never did.

2. **The raw Accept header must not reach `serialize()`.** `Imager.serialize` derives the image format from it — `format=accept.split("/")[-1].upper()` — so once lists and parameters are tolerated, `text/html;q=0.9, image/png;q=0.8` asks PIL for format `PNG;Q=0.8`:

   ```
   raw header -> KeyError 'PNG;Q=0.8'
   resolved   -> image/png   69 bytes
   ```

   `Response(media_type=accept)` would also echo the entire header back as the response Content-Type. So `resolve_accept()` returns the one media type we answer with, and that value is what serializes and labels the response.

## Tests

New `tests/unit/test_serialization.py`, 31 cases — parameters, casing, `audio/AMR-WB`, octet-stream per task, the missing/unsupported errors, Accept lists with q-values, and that `resolve_accept` returns a bare media type. The module had no test coverage at all before. `ruff check src tests` clean; the rest of the unit suite unaffected (`test_pt_sentence_transformers_pipeline` fails in my local env only, for lack of the `st` extra — identically on unmodified `main`).

## Pre-existing wart, not touched

`Accept: image/jpg` and `image/x-image` are in the mapping but ask PIL for formats `JPG` / `X-IMAGE`, which it doesn't know. That is broken on main today and this PR neither fixes nor worsens it — mentioning it so it isn't mistaken for fallout.