### PR TITLE
perf(sentence-transformers): serialize float32 embeddings without .tolist(), and stop walking dirs at startup

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -23,5 +23,7 @@ ffmpeg
 starlette>=1.0.1
 uvicorn
 pandas
+# Direct import in src/ (embedding serialization), not just a transitive dep
+numpy
 orjson
 einops

--- a/src/huggingface_inference_toolkit/optimum_utils.py
+++ b/src/huggingface_inference_toolkit/optimum_utils.py
@@ -95,7 +95,7 @@ def get_optimum_neuron_pipeline(task, model_dir):
 
     # check if model is already converted and has input shapes available
     export = True
-    if NEURON_FILE_NAME in os.listdir(model_dir):
+    if os.path.exists(os.path.join(model_dir, NEURON_FILE_NAME)):
         export = False
     if export:
         logger.info(

--- a/src/huggingface_inference_toolkit/sentence_transformers_utils.py
+++ b/src/huggingface_inference_toolkit/sentence_transformers_utils.py
@@ -1,6 +1,8 @@
 import importlib.util
 from typing import Any, Dict, List, Tuple, Union
 
+import numpy as np
+
 from huggingface_inference_toolkit.env_utils import api_inference_compat
 
 try:
@@ -37,9 +39,11 @@ class SentenceEmbeddingPipeline:
         # `device` needs to be set to "cuda" for GPU
         self.model = SentenceTransformer(model_dir, device=device, **kwargs)
 
-    def __call__(self, sentences: Union[str, List[str]]) -> Dict[str, List[float]]:
-        embeddings = self.model.encode(sentences).tolist()
-        # The widgets expect the bare list, not a wrapper object
+    def __call__(self, sentences: Union[str, List[str]]) -> Union[np.ndarray, Dict[str, np.ndarray]]:
+        # Deliberately not `.tolist()`: it widens float32 to float64 and serializes
+        # 0.1 as 0.10000000149011612.
+        embeddings = self.model.encode(sentences)
+        # The widgets expect the bare array, not a wrapper object
         return embeddings if api_inference_compat() else {"embeddings": embeddings}
 
 

--- a/src/huggingface_inference_toolkit/serialization/json_utils.py
+++ b/src/huggingface_inference_toolkit/serialization/json_utils.py
@@ -13,7 +13,14 @@ def default(obj):
             png_string = out.getvalue()
             return base64.b64encode(png_string).decode("utf-8")
     if isinstance(obj, np.ndarray):
-        # `OPT_SERIALIZE_NUMPY` rejects non-C-contiguous arrays and defers them here.
+        # `OPT_SERIALIZE_NUMPY` defers an array here for one of two reasons.
+        if not obj.flags["C_CONTIGUOUS"]:
+            # Not C-contiguous, e.g. a truncated embedding (`a[:, :256]`). Copy into a
+            # contiguous buffer so it goes back through orjson's native path, which keeps the
+            # float32 formatting; `.tolist()` would widen to float64 and undo the size win.
+            return np.ascontiguousarray(obj)
+        # Contiguous, so the dtype is one orjson cannot handle. Hand back the elements and let
+        # them be serialized individually, or fail here if they cannot be.
         return obj.tolist()
     raise TypeError
 

--- a/src/huggingface_inference_toolkit/serialization/json_utils.py
+++ b/src/huggingface_inference_toolkit/serialization/json_utils.py
@@ -1,6 +1,7 @@
 import base64
 from io import BytesIO
 
+import numpy as np
 import orjson
 from PIL import Image
 
@@ -11,6 +12,9 @@ def default(obj):
             obj.save(out, format="PNG")
             png_string = out.getvalue()
             return base64.b64encode(png_string).decode("utf-8")
+    if isinstance(obj, np.ndarray):
+        # `OPT_SERIALIZE_NUMPY` rejects non-C-contiguous arrays and defers them here.
+        return obj.tolist()
     raise TypeError
 
 

--- a/src/huggingface_inference_toolkit/webservice_starlette.py
+++ b/src/huggingface_inference_toolkit/webservice_starlette.py
@@ -35,7 +35,7 @@ from huggingface_inference_toolkit.vertex_ai_utils import _load_repository_from_
 async def prepare_model_artifacts():
     global inference_handler
     # 1. check if model artifacts available in HF_MODEL_DIR
-    if len(list(Path(HF_MODEL_DIR).glob("**/*"))) <= 0:
+    if next(Path(HF_MODEL_DIR).glob("**/*"), None) is None:
         # 2. if not available, try to load from HF_MODEL_ID
         if HF_MODEL_ID is not None:
             _load_repository_from_hf(

--- a/tests/unit/test_handler.py
+++ b/tests/unit/test_handler.py
@@ -1,6 +1,7 @@
 import tempfile
 from typing import Dict
 
+import numpy as np
 import pytest
 from transformers.testing_utils import require_tf, require_torch
 
@@ -69,7 +70,7 @@ def test_pt_sentence_transformers_pipeline(input_data: Dict[str, str]) -> None:
         )
         h = get_inference_handler_either_custom_or_default_handler(str(storage_dir), task="sentence-embeddings")
         pred = h(input_data)
-        assert isinstance(pred["embeddings"], list)
+        assert isinstance(pred["embeddings"], np.ndarray)
 
 
 @require_tf

--- a/tests/unit/test_sentence_transformers.py
+++ b/tests/unit/test_sentence_transformers.py
@@ -1,5 +1,6 @@
 import tempfile
 
+import numpy as np
 import pytest
 from transformers.testing_utils import require_torch
 
@@ -27,9 +28,9 @@ def test_sentence_embedding_task():
         storage_dir = _load_repository_from_hf("sentence-transformers/all-MiniLM-L6-v2", tmpdirname)
         pipe = get_sentence_transformers_pipeline("sentence-embeddings", storage_dir.as_posix())
         res = pipe(sentences="Lets create an embedding")
-        assert isinstance(res["embeddings"], list)
+        assert isinstance(res["embeddings"], np.ndarray)
         res = pipe(sentences=["Lets create an embedding", "Lets create another embedding"])
-        assert isinstance(res["embeddings"], list)
+        assert isinstance(res["embeddings"], np.ndarray)
         assert len(res["embeddings"]) == 2
 
 


### PR DESCRIPTION
What changed, why, what was measured, and — importantly — what was not.

## Summary

| File | Change | Practical impact |
| --- | --- | --- |
| `sentence_transformers_utils.py` | Return the float32 embedding array instead of `.tolist()` | Real, but scales with batch size. ~45% smaller responses, ~1.3-1.5x faster serialization |
| `serialization/json_utils.py` | Handle `np.ndarray` in the `default()` hook | Closes a latent gap the change above makes reachable. Keeps truncated embeddings compact |
| `webservice_starlette.py` | `next(glob, None)` instead of `len(list(glob))` | Hygiene. Avoids a pathological case on network-mounted model dirs |
| `optimum_utils.py` | `os.path.exists` instead of `in os.listdir` | Hygiene. Sub-millisecond, once, at startup |
| `requirements.txt` | Declare `numpy` | `numpy` became a direct import in `src/` |
| `tests/unit/*` | `list` -> `np.ndarray` assertions | Follows the contract change below |

## Rebased onto main

Two conflicts, both resolved in favour of what landed on `main` since this branch was cut:

- **`setup.py` -> `requirements.txt`.** #132 replaced the inline `install_requires` list with
  `requirements("requirements.txt")`, so declaring `numpy` in `setup.py` would have been dead
  code. `setup.py` is left byte-identical to `main` and the declaration went where the pins
  now live.
- **`SentenceEmbeddingPipeline.__call__`.** #131 added the `API_INFERENCE_COMPAT` branch that
  returns the embeddings unwrapped for the Hub widgets. Both behaviours are kept:

  ```python
  def __call__(self, sentences) -> Union[np.ndarray, Dict[str, np.ndarray]]:
      embeddings = self.model.encode(sentences)
      return embeddings if api_inference_compat() else {"embeddings": embeddings}
  ```

  The wire format is unchanged in both modes.

## 1. Embeddings are no longer converted with `.tolist()`

`SentenceTransformer.encode()` returns a **float32** array. The previous code called
`.tolist()` on it, which widens every value to a Python `float` (float64). orjson then
prints the full float64 expansion of a number that only ever carried float32 precision:

```
.tolist() : {"embeddings":[[0.10000000149011612,0.3333333432674408,0.12345679104328156]]}
numpy     : {"embeddings":[[0.1,0.33333334,0.12345679]]}
```

The extra digits carry **no information**. Both forms parse back to bit-identical float32
values (verified with `np.array_equal` after a round trip). `Jsoner` already passes
`orjson.OPT_SERIALIZE_NUMPY`, so orjson can serialize the array directly.

### Measured

Serialization cost and payload size, 384 dimensions (the width of
`sentence-transformers/all-MiniLM-L6-v2`, used by this repo's own tests):

| batch | CPU saved | bytes saved | transfer @1 Gbps | transfer @100 Mbps |
| --- | --- | --- | --- | --- |
| 1 | 0.003 ms | 3 KB | 0.03 ms | 0.26 ms |
| 8 | 0.026 ms | 26 KB | 0.21 ms | 2.1 ms |
| 128 | 0.34 ms | 425 KB | 3.4 ms | 34 ms |
| 512 | 1.9 ms | 1.7 MB | 13.6 ms | 136 ms |
| 2048 | 8.8 ms | 6.8 MB | 54 ms | 544 ms |

The transfer columns are `bytes / bandwidth` arithmetic, ignoring TCP and TLS overhead.

**This change is invisible at batch 1** and only pays off on large batches, mostly through
transfer rather than CPU. Its value therefore depends on the batch-size distribution of real
traffic.

### It survives gzip

The obvious objection is that a reverse proxy doing gzip would compress the redundant digits
away. It does not — they are high-entropy, so they compress poorly:

| | raw | gzip-6 |
| --- | --- | --- |
| `.tolist()` | 3,789,453 | 1,718,172 |
| numpy | 2,090,166 | 883,535 |

The reduction from this change is **44.8% raw, 48.6% after gzip-6**. Note also that this
repo configures no compression middleware, so raw sizes are what ship unless something in
front adds it.

### Secondary benefit: less event-loop blocking

`predict()` serializes the response **synchronously on the event loop**, after the
threadpool call returns. So this also shortens the window during which the process cannot
answer anything else, including `/health` and `/metrics`: 23.9 ms -> 15.1 ms at batch 2048.

### Contract change (relevant to reviewers)

`SentenceEmbeddingPipeline.__call__` now hands back the `np.ndarray` in place of the nested
lists, in both response shapes: `Dict[str, np.ndarray]` normally, and the bare array under
`API_INFERENCE_COMPAT` (which returns the embeddings unwrapped for the widgets). **The HTTP
JSON response is byte-for-byte the same shape in both modes** — only the Python-level return
type changed. Two unit assertions were updated accordingly
(`test_sentence_transformers.py`, `test_handler.py`). Anything consuming the handler
directly in Python rather than over HTTP would need to account for this.

The precision claim is worth stating exactly: the shorter digits round-trip to a
bit-identical **float32**, which is what the model produced. A consumer that parses the JSON
into float64 and never narrows does see different float64 values — by at most ~6e-8
relative, an order of magnitude below float32 epsilon (1.2e-7), i.e. within the noise that
was already there.

### The `json_utils.default()` branch

`OPT_SERIALIZE_NUMPY` defers an array to the `default()` hook for two distinct reasons, and
they want different answers:

| deferred because | handling | why |
| --- | --- | --- |
| not C-contiguous | `np.ascontiguousarray(obj)` | orjson can serialize the values fine, it just will not read a strided buffer. One copy puts it back on the native path and keeps float32 formatting |
| unsupported dtype | `obj.tolist()` | `ascontiguousarray` would return the same unsupported array and re-enter `default()` until orjson's recursion limit |

This matters beyond not crashing. `.tolist()` re-widens float32, so routing non-contiguous
arrays through it would hand back exactly the float64 digits this PR removes — a 4x256
truncated embedding serializes to 19,737 bytes via `.tolist()` against 10,916 contiguous
(44.7% larger), with identical float32 values.

That case is the likely one in practice: slicing the last axis is what Matryoshka truncation
does, and `a[:, :256]` is not contiguous. Note this gap predates the PR — `OPT_SERIALIZE_NUMPY`
was already set, so a non-contiguous array from any pipeline would already have failed. What
changed is that an ndarray now reaches the serializer on every embeddings request.

Unsupported dtypes still raise `TypeError` (verified for complex64, object and longdouble):
they are not representable in JSON, and no recursion occurs.

### Deliberately left alone

- `SentenceRankingPipeline` keeps its `.tolist()`. For a single pair it returns a 0-d numpy
  scalar, and `.tolist()` turns that into a Python `float`. Removing it would yield
  `np.float32` — which is *not* a `float` subclass — breaking the documented return type for
  a negligible payload gain.
- `SentenceSimilarityPipeline` keeps its `.tolist()`. It operates on torch tensors, which
  `OPT_SERIALIZE_NUMPY` does not cover.

## 2 and 3. Startup directory scans

`webservice_starlette.py` tested whether the model directory was empty with
`len(list(Path(HF_MODEL_DIR).glob("**/*"))) <= 0`, which recursively walks the entire model
tree and materializes every path just to answer "is there anything here". `next(glob, None)`
stops at the first entry. Semantics were verified identical on all three cases: non-empty,
empty, and missing directory (both report empty, no new exception).

`optimum_utils.py` listed a whole directory to test for one filename.

**These are hygiene, not a performance win, and it is worth being blunt about that.** The
measured multipliers (103x and 76x on local APFS) are real but apply to trivial absolute
numbers — 3.5 ms and 0.12 ms, once, at startup, against model loading that takes seconds to
minutes. They round to zero.

Their actual justification is narrower: avoiding a pathological case on network-mounted
model directories (EFS, s3fs, blobfuse), where each directory entry is a round trip and a
recursive walk of a large tree can take seconds. **That case was not measured** — the
benchmark ran on local disk. Treat it as reasoning, not evidence.

## Limitations

- **No end-to-end measurement.** Request latency and throughput through Starlette/uvicorn
  were not measured. All figures above are component-level microbenchmarks.
- The missing number is serialization time as a **fraction of real request time**. If
  encoding 512 sentences takes 1-3 s on CPU, the 1.9 ms CPU saving is under 0.2% of the
  request and only the transfer saving is visible.
- The two changed assertions are `@require_torch` and need `sentence_transformers`, so they
  are exercised by CI rather than locally. The rest of `tests/unit` was run against this
  change and against `main` for comparison: identical results, no new failures.
  `ruff check src tests` passes.
- Getting a defensible end-to-end number means running the container and hitting `/predict`
  with a batch sweep (`make inference-pytorch-cpu`, then the integ tests).

## Out of scope here

Found during the audit, deliberately not fixed here. The two content-type findings this list
originally carried — exact-string media-type matching, and `Accept` headers with parameters
such as `image/png; q=0.9` — were since fixed on `main` by #130 and have been dropped.

### Correctness bugs (warrant their own branch)

- **`Accept: image/jpg` returns a 400.** `image_utils.py` does
  `accept.split("/")[-1].upper()`, so the listed-as-supported `image/jpg` yields `"JPG"`,
  which PIL rejects with `KeyError`.
- **Float and negative query parameters silently stay strings.** `convert_params_to_int_or_bool`
  uses `str.isnumeric()`, and both `"0.5".isnumeric()` and `"-1".isnumeric()` are `False`,
  so `?temperature=0.5` reaches the pipeline as a string. The three `if`s should also be
  `elif`.
- **`_load_repository_from_hf` ignores `revision` when probing for safetensors.**
  `HfApi().model_info(repository_id)` queries the default branch even when `HF_REVISION` is
  set, and that answer selects the download ignore-patterns. If the pinned revision differs
  in weight format, the filter is wrong for the revision actually downloaded.
- **Audio base64 decoding is gated on `"parameters" in body`** (`webservice_starlette.py`),
  so `{"inputs": "<base64>"}` without `parameters` is never decoded. Git history shows this
  is deliberate (`cb6b427`), so it needs the author's intent before being changed.

### Measured and rejected

The task-dispatch chain in `HuggingFaceHandler.__call__` re-reads `self.pipeline.task` about
eight times and runs four substring scans per request, all invariant after `__init__`. It
looks like an obvious hoist, but it costs **0.15 us/request — 0.0003% of a 50 ms
inference**. Hoisting it into `__init__` is a readability improvement, not a performance
one, and should not be sold as the latter. Same category: the double dict lookup in
`ContentType`, `functools.partial` in `async_utils.py`, and `create_artifact_filter`
rebuilding its set on each call.

### Architectural

`MAX_CONCURRENT_THREADS = 1` (`async_utils.py`) is the real throughput ceiling: exactly one
request is in the model at a time and there is no request batching. An embeddings endpoint
that could serve a batch of 64 in roughly the time of one serves them serially. This is
deliberate and correct for a single GPU; changing it means dynamic batching, which is an
architectural project rather than a code tweak.

### Dependencies

Pins are roughly 15 months stale (`transformers==4.51.3`, `huggingface_hub==0.30.2`,
`torch==2.5.1`, `sentence_transformers==4.0.2`). The more pressing issues are not the stale
pins:

- **`torchvision` and `torchaudio` are unpinned next to `torch==2.5.1`** in
  `requirements-torch.txt`. They must match torch's minor version; pip can resolve an
  incompatible pair and fail at import. This is a latent build break independent of any
  upgrade.
- **Half of `requirements.txt` floats** (Pillow, librosa, phonemizer, uvicorn, pandas,
  orjson, einops — and now numpy), so image builds are not reproducible.
- **`"ffmpeg"` is a dead dependency** — nothing imports it, and the PyPI package of that
  name is an abandoned 2018 wrapper, not the binary. The Dockerfile already apt-installs the
  real one.
- **`mock==2.0.0`** dates from 2017; `unittest.mock` has been stdlib since 3.3.
- **`kenlm` is pinned to a git SHA** whose comment references an upstream fix that has since
  landed, so it may be installable from PyPI now, dropping a compiler from the build.
- `sentence_transformers` 4 -> 5 is the one upgrade that could interact with these changes,
  since v5 reworked parts of the `encode()` API.

## Reproducing the benchmarks

```python
import numpy as np, orjson, gzip, timeit

def old(a): return orjson.dumps({"embeddings": a.tolist()}, option=orjson.OPT_SERIALIZE_NUMPY)
def new(a): return orjson.dumps({"embeddings": a},          option=orjson.OPT_SERIALIZE_NUMPY)

arr = np.random.rand(512, 384).astype(np.float32)

# no loss of float32 precision
assert np.array_equal(
    np.array(orjson.loads(old(arr))["embeddings"], dtype=np.float32),
    np.array(orjson.loads(new(arr))["embeddings"], dtype=np.float32),
)

print(len(old(arr)), len(new(arr)))                                  # raw bytes
print(len(gzip.compress(old(arr), 6)), len(gzip.compress(new(arr), 6)))  # after gzip
print(timeit.timeit(lambda: old(arr), number=200) / 200 * 1000, "ms")
print(timeit.timeit(lambda: new(arr), number=200) / 200 * 1000, "ms")
```
