### PR TITLE
feat(compat): answer with the shapes the Inference API widgets expect

### DIFF
--- a/src/huggingface_inference_toolkit/env_utils.py
+++ b/src/huggingface_inference_toolkit/env_utils.py
@@ -1,3 +1,6 @@
+import os
+
+
 def strtobool(val: str) -> bool:
     """Convert a string representation of truth to True or False booleans.
     True values are 'y', 'yes', 't', 'true', 'on', and '1'; false values
@@ -20,3 +23,12 @@ def strtobool(val: str) -> bool:
     raise ValueError(
         f"Invalid truth value, it should be a string but {val} was provided instead."
     )
+
+
+def api_inference_compat() -> bool:
+    """
+    Whether to answer with the response shapes the Inference API / Hub widgets expect.
+
+    Read on every call rather than cached at import: tests toggle it, and it costs nothing.
+    """
+    return strtobool(os.getenv("API_INFERENCE_COMPAT", "false"))

--- a/src/huggingface_inference_toolkit/handler.py
+++ b/src/huggingface_inference_toolkit/handler.py
@@ -3,6 +3,8 @@ from pathlib import Path
 from typing import Any, Dict, Literal, Optional, Union
 
 from huggingface_inference_toolkit.const import HF_TRUST_REMOTE_CODE
+from huggingface_inference_toolkit.env_utils import api_inference_compat
+from huggingface_inference_toolkit.logging import logger
 from huggingface_inference_toolkit.sentence_transformers_utils import SENTENCE_TRANSFORMERS_TASKS
 from huggingface_inference_toolkit.utils import (
     check_and_register_custom_pipeline_from_directory,
@@ -101,9 +103,113 @@ class HuggingFaceHandler:
                     "or `candidateLabels`."
                 )
 
-        return (
+        if api_inference_compat():
+            if self.pipeline.task == "text-classification" and isinstance(inputs, str):
+                # A single string is sent as a batch of one, with the whole ranking asked for
+                # rather than the top label alone. Left as is for a list of inputs: defaulting
+                # top_k there would change how many labels each one comes back with.
+                inputs = [inputs]
+                parameters.setdefault("top_k", int(os.environ.get("DEFAULT_TOP_K", 5)))
+            if self.pipeline.task == "token-classification":
+                parameters.setdefault(
+                    "aggregation_strategy", os.environ.get("DEFAULT_AGGREGATION_STRATEGY", "simple")
+                )
+
+        resp = (
             self.pipeline(**inputs, **parameters) if isinstance(inputs, dict) else self.pipeline(inputs, **parameters)  # type: ignore
         )
+
+        if api_inference_compat():
+            resp = self._reshape_for_api_inference_compat(inputs, resp)
+
+        return resp
+
+    def _reshape_for_api_inference_compat(self, inputs: Any, resp: Any) -> Any:
+        """
+        Adapt a pipeline's output to the shape the Inference API / Hub widgets expect.
+
+        Every branch degrades to the untouched response and a warning when the output does not
+        look the way it should: a display concern must never turn a successful inference into an
+        error.
+        """
+        if self.pipeline.task == "text-classification":
+            # Always one ranking per input. A flat response means one entry per input, which is the
+            # same thing as a single ranking only when there was exactly one input — so the number
+            # of inputs in the request decides, not the shape of the response. Reading the shape
+            # alone would turn N top-1 results into what looks like one N-label ranking, losing
+            # which result belongs to which input.
+            if not isinstance(resp, list) or (resp and isinstance(resp[0], list)):
+                return resp  # already grouped per input
+            if isinstance(inputs, str):
+                n_inputs = 1
+            elif isinstance(inputs, list):
+                n_inputs = len(inputs)
+            else:
+                logger.warning("Cannot group text-classification scores, unexpected inputs type %s", type(inputs))
+                return resp
+            if n_inputs == 1:
+                return [resp]
+            if len(resp) != n_inputs:
+                logger.warning("Inputs and resp len differ, %d != %d", n_inputs, len(resp))
+                return resp
+            # One entry per input: group each on its own so the shape stays list[list[dict]]
+            # whatever the input count, without changing how many labels came back.
+            return [[entry] for entry in resp]
+
+        if self.pipeline.task == "feature-extraction":
+            # Transformers returns the headless encoder outputs, shaped
+            # [n_inputs, batch_size = 1, n_tokens, n_hidden]. The batch dim is always 1 here, so
+            # drop it and hand back a 2D/3D array.
+            # https://github.com/huggingface/transformers/blob/5c47d08b/src/transformers/pipelines/feature_extraction.py#L27
+            if isinstance(inputs, list):
+                if not isinstance(resp, list) or len(resp) != len(inputs):
+                    logger.warning(
+                        "Inputs and resp len differ (or resp is not a list, type %s)", type(resp)
+                    )
+                    return resp
+                squeezed = []
+                for embeddings in resp:
+                    if not isinstance(embeddings, list) or len(embeddings) != 1:
+                        logger.warning("One of the output batch size differs from 1: %d", len(embeddings))
+                        return resp
+                    squeezed.append(embeddings[0])
+                return squeezed
+            if isinstance(inputs, str):
+                if isinstance(resp, list) and len(resp) == 1:
+                    return resp[0]
+                logger.warning("The output batch size differs from 1: %d", len(resp))
+                return resp
+            logger.warning("Output unexpected type %s", type(resp))
+            return resp
+
+        if self.pipeline.task == "image-segmentation":
+            # Semantic segmentation reports no per-mask score, but the widget needs one
+            if isinstance(resp, list):
+                for element in resp:
+                    if isinstance(element, dict) and element.get("score") is None:
+                        element["score"] = 1
+            return resp
+
+        if self.pipeline.task == "zero-shot-classification":
+            # Parallel labels/scores arrays -> the [{label, score}] the widget renders
+            if not isinstance(resp, dict) or "labels" not in resp or "scores" not in resp:
+                logger.warning("Unable to remap response for api inference compat, unexpected shape")
+                return resp
+            labels, scores = resp["labels"], resp["scores"]
+            if len(labels) != len(scores):
+                logger.warning(
+                    "Unable to remap response for api inference compat, "
+                    "labels and scores do not have the same len, %d != %d",
+                    len(labels),
+                    len(scores),
+                )
+                return resp
+            return [
+                {"label": label, "score": score}
+                for label, score in zip(labels, scores, strict=True)  # lengths checked above
+            ]
+
+        return resp
 
 
 class VertexAIHandler(HuggingFaceHandler):

--- a/src/huggingface_inference_toolkit/sentence_transformers_utils.py
+++ b/src/huggingface_inference_toolkit/sentence_transformers_utils.py
@@ -1,6 +1,8 @@
 import importlib.util
 from typing import Any, Dict, List, Tuple, Union
 
+from huggingface_inference_toolkit.env_utils import api_inference_compat
+
 try:
     from typing import Literal
 except ImportError:
@@ -26,7 +28,8 @@ class SentenceSimilarityPipeline:
         embeddings1 = self.model.encode(source_sentence, convert_to_tensor=True)
         embeddings2 = self.model.encode(sentences, convert_to_tensor=True)
         similarities = util.pytorch_cos_sim(embeddings1, embeddings2).tolist()[0]
-        return {"similarities": similarities}
+        # The widgets expect the bare list, not a wrapper object
+        return similarities if api_inference_compat() else {"similarities": similarities}
 
 
 class SentenceEmbeddingPipeline:
@@ -36,7 +39,8 @@ class SentenceEmbeddingPipeline:
 
     def __call__(self, sentences: Union[str, List[str]]) -> Dict[str, List[float]]:
         embeddings = self.model.encode(sentences).tolist()
-        return {"embeddings": embeddings}
+        # The widgets expect the bare list, not a wrapper object
+        return embeddings if api_inference_compat() else {"embeddings": embeddings}
 
 
 class SentenceRankingPipeline:

--- a/tests/unit/test_api_inference_compat.py
+++ b/tests/unit/test_api_inference_compat.py
@@ -1,0 +1,194 @@
+import pytest
+
+from huggingface_inference_toolkit.env_utils import api_inference_compat
+from huggingface_inference_toolkit.handler import HuggingFaceHandler
+
+
+class FakePipeline:
+    """A transformers-pipeline stand-in: a task name and a recorded call."""
+
+    def __init__(self, task, returns=None):
+        self.task = task
+        self.returns = returns
+        self.calls = []
+
+    def __call__(self, *args, **kwargs):
+        # dict inputs are spread as kwargs by the handler, everything else is positional
+        self.calls.append((args[0] if args else None, kwargs))
+        return self.returns
+
+
+def handler_for(task, returns=None):
+    # bypass __init__, which would load a model
+    handler = HuggingFaceHandler.__new__(HuggingFaceHandler)
+    handler.pipeline = FakePipeline(task, returns)
+    return handler
+
+
+@pytest.fixture
+def compat_on(monkeypatch):
+    monkeypatch.setenv("API_INFERENCE_COMPAT", "true")
+
+
+@pytest.mark.parametrize(
+    "value,expected",
+    [(None, False), ("false", False), ("0", False), ("true", True), ("1", True), ("YES", True)],
+)
+def test_api_inference_compat_env(monkeypatch, value, expected):
+    if value is None:
+        monkeypatch.delenv("API_INFERENCE_COMPAT", raising=False)
+    else:
+        monkeypatch.setenv("API_INFERENCE_COMPAT", value)
+    assert api_inference_compat() is expected
+
+
+def test_off_by_default_leaves_the_response_untouched(monkeypatch):
+    monkeypatch.delenv("API_INFERENCE_COMPAT", raising=False)
+    flat = [{"label": "POSITIVE", "score": 0.9}]
+    handler = handler_for("text-classification", returns=flat)
+
+    assert handler({"inputs": "good"}) is flat
+    # no top_k default injected either
+    assert handler.pipeline.calls == [("good", {})]
+
+
+def test_text_classification_batches_a_single_string_and_asks_for_the_ranking(compat_on):
+    nested = [[{"label": "POSITIVE", "score": 0.9}, {"label": "NEGATIVE", "score": 0.1}]]
+    handler = handler_for("text-classification", returns=nested)
+
+    assert handler({"inputs": "good"}) == nested
+    assert handler.pipeline.calls == [(["good"], {"top_k": 5})]
+
+
+def test_default_top_k_is_passed_as_an_int(compat_on, monkeypatch):
+    # it reaches the pipeline as a string otherwise, which transformers rejects
+    monkeypatch.setenv("DEFAULT_TOP_K", "3")
+    handler = handler_for("text-classification", returns=[[]])
+
+    handler({"inputs": "good"})
+
+    assert handler.pipeline.calls == [(["good"], {"top_k": 3})]
+
+
+def test_caller_parameters_win_over_the_defaults(compat_on):
+    handler = handler_for("text-classification", returns=[[]])
+
+    handler({"inputs": "good", "parameters": {"top_k": 1}})
+
+    assert handler.pipeline.calls == [(["good"], {"top_k": 1})]
+
+
+def test_token_classification_gets_an_aggregation_strategy(compat_on):
+    handler = handler_for("token-classification", returns=[])
+
+    handler({"inputs": "Wolfgang lives in Berlin"})
+
+    assert handler.pipeline.calls == [("Wolfgang lives in Berlin", {"aggregation_strategy": "simple"})]
+
+
+A = {"label": "A", "score": 0.9}
+B = {"label": "B", "score": 0.1}
+
+
+@pytest.mark.parametrize(
+    "inputs,resp,expected",
+    [
+        # one input, flat ranking -> the whole list is that input's ranking
+        (["a"], [A, B], [[A, B]]),
+        (["a"], [A], [[A]]),
+        # already grouped per input: untouched
+        (["a"], [[A, B]], [[A, B]]),
+        (["a", "b"], [[A], [B]], [[A], [B]]),
+        # several inputs, flat: one entry per input (what top_k=1 returns), so group each on its
+        # own rather than wrapping the lot — wrapping would lose which result belongs to which input
+        (["a", "b", "c"], [A, B, A], [[A], [B], [A]]),
+        ([], [], []),
+    ],
+)
+def test_text_classification_groups_scores_per_input(compat_on, inputs, resp, expected):
+    handler = handler_for("text-classification", returns=resp)
+    assert handler({"inputs": inputs}) == expected
+
+
+def test_text_classification_leaves_a_length_mismatch_alone(compat_on):
+    # 2 inputs but 3 results: we cannot tell how they map, so do not invent a grouping
+    resp = [A, B, A]
+    handler = handler_for("text-classification", returns=resp)
+    assert handler({"inputs": ["a", "b"]}) == resp
+
+
+def test_text_classification_does_not_default_top_k_for_list_inputs(compat_on):
+    # only a single string is batched and given the full ranking; defaulting top_k here would
+    # change how many labels each input comes back with
+    handler = handler_for("text-classification", returns=[A, B])
+    handler({"inputs": ["a", "b"]})
+    assert handler.pipeline.calls == [(["a", "b"], {})]
+
+
+def test_feature_extraction_drops_the_batch_dimension(compat_on):
+    handler = handler_for("feature-extraction", returns=[[[1.0, 2.0]], [[3.0, 4.0]]])
+    assert handler({"inputs": ["a", "b"]}) == [[1.0, 2.0], [3.0, 4.0]]
+
+    handler = handler_for("feature-extraction", returns=[[[1.0, 2.0]]])
+    assert handler({"inputs": "a"}) == [[1.0, 2.0]]
+
+
+@pytest.mark.parametrize(
+    "inputs,resp",
+    [
+        # resp/input length mismatch
+        (["a", "b"], [[[1.0]]]),
+        # a batch dimension that is not 1
+        (["a"], [[[1.0], [2.0]]]),
+        # more than one embedding for a single string input
+        ("a", [[[1.0]], [[2.0]]]),
+        # not a list at all
+        (["a"], {"unexpected": True}),
+    ],
+)
+def test_feature_extraction_leaves_unexpected_shapes_alone(compat_on, inputs, resp):
+    handler = handler_for("feature-extraction", returns=resp)
+    assert handler({"inputs": inputs}) == resp
+
+
+def test_image_segmentation_gets_a_score(compat_on):
+    handler = handler_for(
+        "image-segmentation",
+        returns=[{"label": "cat", "mask": "..."}, {"label": "dog", "mask": "...", "score": 0.5}],
+    )
+
+    assert handler({"inputs": "img"}) == [
+        {"label": "cat", "mask": "...", "score": 1},
+        {"label": "dog", "mask": "...", "score": 0.5},
+    ]
+
+
+def test_zero_shot_classification_becomes_label_score_pairs(compat_on):
+    handler = handler_for(
+        "zero-shot-classification",
+        returns={"sequence": "s", "labels": ["a", "b"], "scores": [0.7, 0.3]},
+    )
+
+    assert handler({"inputs": "s", "parameters": {"candidate_labels": ["a", "b"]}}) == [
+        {"label": "a", "score": 0.7},
+        {"label": "b", "score": 0.3},
+    ]
+
+
+@pytest.mark.parametrize(
+    "resp",
+    [
+        {"labels": ["a", "b"], "scores": [0.7]},  # parallel arrays of different length
+        {"labels": ["a"]},  # scores missing
+        [{"label": "a", "score": 1.0}],  # not a dict
+    ],
+)
+def test_zero_shot_classification_leaves_unexpected_shapes_alone(compat_on, resp):
+    handler = handler_for("zero-shot-classification", returns=resp)
+    assert handler({"inputs": "s", "parameters": {"candidate_labels": ["a"]}}) == resp
+
+
+def test_an_unmapped_task_is_passed_through(compat_on):
+    resp = {"answer": "42", "score": 0.9}
+    handler = handler_for("question-answering", returns=resp)
+    assert handler({"inputs": {"question": "q", "context": "c"}}) is resp


### PR DESCRIPTION
Next step of the progressive port of `api-inference-mini-fork` onto `main`, sourced from `46fa298` (last fork commit before the transformers 5.x bump). This is the `API_INFERENCE_COMPAT` output-compat half of the fork's big commit; the `/pipeline/{task}` route and the per-task handler cache stay behind until the async-load PR, since they build pipelines inside a request.

**Off by default** — without `API_INFERENCE_COMPAT=1` nothing here changes behaviour, and there is a test pinning that.

## Response shapes

| task | with compat on |
|---|---|
| text-classification | one ranking per input, always `list[list[dict]]`; a lone string is sent as a batch of one with `top_k` defaulted so the whole ranking comes back instead of the top label |
| feature-extraction | batch dimension dropped: transformers returns `[n_inputs, batch_size = 1, n_tokens, n_hidden]` and that middle axis is always 1 here |
| image-segmentation | `score = 1` where the model reports none, as semantic segmentation does |
| zero-shot-classification | parallel `labels` / `scores` arrays become `[{label, score}]` |
| sentence-similarity / sentence-embeddings | the bare list instead of `{"similarities": ...}` / `{"embeddings": ...}` |

Parameter defaults, both via `setdefault` so an explicit request parameter always wins: `DEFAULT_TOP_K` (text-classification) and `DEFAULT_AGGREGATION_STRATEGY` (token-classification).

Every reshaping branch degrades to the untouched response plus a warning when the output doesn't look the way it should — a display concern must not turn a successful inference into an error.

## Changes on top of the fork

**1. `DEFAULT_TOP_K` is cast to `int`.** Set via env it reached the pipeline as a string, which transformers rejects. The fork fixed this later in `cb183b7`; folded in here since it belongs to this feature.

**2. text-classification grouping is decided by the request, not by the response shape.** These are transformers' actual outputs:

| request | `top_k` | pipeline returns |
|---|---|---|
| `"hello"` | unset | `[{…}]` |
| `["a","b","c"]` | unset | `[{…}, {…}, {…}]` ← the top label of **each** input |
| `["a","b","c"]` | 2 | `[[{…},{…}], …]` |

A flat response means "one entry per input", which is the same thing as "one ranking" only when there was exactly one input. The fork wraps any flat response, so a 3-input request with no `top_k` came back as `[[a, b, c]]` — indistinguishable from one input with three labels, and with no way for the caller to recover which result belonged to which input.

Now the input count decides: one input yields `[[…]]`, several yield `[[a], [b], [c]]`. Verified against the real pipeline:

```
1 string            -> [[{label,score}, {label,score}]]
list of 1           -> [[{label,score}]]
list of 3           -> [[{label,score}], [{label,score}], [{label,score}]]
list of 2, top_k=2  -> [[{label,score}, {label,score}], [{label,score}, {label,score}]]
list of 3, top_k=1  -> [[{label,score}], [{label,score}], [{label,score}]]
```

`list[list[dict]]` in every case. **Single-input responses — the only ones that were already correct — are unchanged**, so nothing the widget exercises today moves. Note `top_k` is deliberately *not* defaulted for list inputs: that would change how many labels each input comes back with, which is a payload change and isn't needed for correctness.

**3.** The reshaping lives in its own method, and the zero-shot branch validates its input instead of raising an exception to immediately catch itself. Same outcomes in every case. `env_utils` already existed on `main` with `strtobool`, so this only adds the `api_inference_compat()` accessor.

## Tests

New `tests/unit/test_api_inference_compat.py`, 30 cases: env parsing, the off-by-default guarantee, both parameter defaults (including the int cast and caller-wins), the grouping matrix above plus the length-mismatch case, each task's happy path, and the degrade-gracefully path for every unexpected shape. They drive the handler through a fake pipeline, so no model download and no GPU.

`ruff check src tests` clean. Locally the rest of `tests/unit` has 10 pre-existing failures from missing `sentence_transformers` / `google-cloud-storage` — identical set before and after this change (verified by stashing); CI installs those extras.