### PR TITLE
build: multi-stage lean image, pinned requirements files and a real CPU variant

### DIFF
--- a/.github/workflows/unit-test.yaml
+++ b/.github/workflows/unit-test.yaml
@@ -34,12 +34,17 @@ jobs:
     - name: Docker Build
       run: make inference-pytorch-gpu
     - name: Run unit tests
+      # The runtime image ships the venv and the package sources only, no setup.py, so we cannot
+      # `pip install '.[test,...]'` from the workdir. The toolkit and the st/diffusers extras are
+      # already in the image; only the test deps are missing. test-requirements.txt is the `test`
+      # extra, and the two packages next to it are the `google` one.
       run: |
         docker run \
           -e RUN_SLOW='${{ env.RUN_SLOW }}' \
           --gpus all \
           -e CACHE_TEST_DIR='${{ env.CACHE_TEST_DIR }}' \
           -v ./tests:${{ env.CACHE_TEST_DIR }} \
+          -v ./test-requirements.txt:/tmp/test-requirements.txt \
           --entrypoint /bin/bash \
           integration-test-pytorch:gpu \
-          -c "pip install '.[test,st,diffusers,google]' && pytest ${{ env.CACHE_TEST_DIR }}/unit"
+          -c "pip install -r /tmp/test-requirements.txt google-cloud-storage 'crcmod==1.7' && pytest ${{ env.CACHE_TEST_DIR }}/unit"

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ inference-pytorch-gpu:
 
 # Build Docker image for PyTorch on CPU
 inference-pytorch-cpu:
-	docker build --build-arg="BASE_IMAGE=ubuntu:22.04" -f dockerfiles/pytorch/Dockerfile -t integration-test-pytorch:cpu .
+	docker build --build-arg="BASE_IMAGE=ubuntu:22.04" --build-arg="RUNTIME_IMAGE=ubuntu:22.04" --build-arg="TORCH_REQUIREMENTS=requirements-torch-cpu.txt" -f dockerfiles/pytorch/Dockerfile -t integration-test-pytorch:cpu .
 
 # Build Docker image for PyTorch on AWS Inferentia2
 inference-pytorch-inf2:

--- a/dockerfiles/pytorch/Dockerfile
+++ b/dockerfiles/pytorch/Dockerfile
@@ -1,6 +1,54 @@
 ARG BASE_IMAGE=nvidia/cuda:12.1.0-devel-ubuntu22.04
+ARG RUNTIME_IMAGE=nvidia/cuda:12.1.0-runtime-ubuntu22.04
 
-FROM $BASE_IMAGE AS base
+# ── builder: compile kenlm and install every dependency into a venv ──────────────────────────────
+FROM ${BASE_IMAGE} AS builder
+SHELL ["/bin/bash", "-c"]
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && \
+    apt-get install -y software-properties-common && \
+    add-apt-repository ppa:deadsnakes/ppa && \
+    apt-get -y upgrade --only-upgrade systemd openssl cryptsetup && \
+    apt-get install -y \
+      build-essential \
+      cmake \
+      curl \
+      git \
+      gcc \
+      g++ \
+      libprotobuf-dev \
+      protobuf-compiler \
+      python3.11 \
+      python3.11-dev \
+      python3.11-venv \
+      libsndfile1-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.11 1 && \
+    ln -sf /usr/bin/python3.11 /usr/bin/python
+
+RUN python3.11 -m venv /opt/venv
+ENV PATH="/opt/venv/bin:$PATH"
+
+RUN pip install --no-cache-dir --upgrade pip
+
+# The heavy dependencies first, straight from the files setup.py declares them in, so this layer
+# survives a source change. TORCH_REQUIREMENTS picks the flavour: the CPU builds swap in wheels
+# without the bundled CUDA runtime.
+ARG TORCH_REQUIREMENTS=requirements-torch.txt
+COPY requirements.txt ${TORCH_REQUIREMENTS} ./
+RUN pip install --no-cache-dir -r requirements.txt -r ${TORCH_REQUIREMENTS}
+
+# Then the toolkit and its two small extras. The core and torch pins above already satisfy what the
+# package asks for, so nothing heavy is resolved again here.
+# Copying only necessary files as filtered by .dockerignore
+COPY . .
+RUN pip install --no-cache-dir ".[st,diffusers]"
+
+# ── runtime: no compilers, no dev headers, CUDA runtime instead of devel ─────────────────────────
+FROM ${RUNTIME_IMAGE} AS runtime
 SHELL ["/bin/bash", "-c"]
 
 LABEL maintainer="Hugging Face"
@@ -10,45 +58,30 @@ ENV DEBIAN_FRONTEND=noninteractive
 WORKDIR /app
 
 RUN apt-get update && \
-    apt-get install software-properties-common -y && \
+    apt-get install -y software-properties-common && \
     add-apt-repository ppa:deadsnakes/ppa && \
     apt-get -y upgrade --only-upgrade systemd openssl cryptsetup && \
     apt-get install -y \
-    build-essential \
-    bzip2 \
-    cmake \
-    curl \
-    git \
-    git-lfs \
-    tar \
-    gcc \
-    g++ \
-    libprotobuf-dev \
-    protobuf-compiler \
-    python3.11 \
-    python3.11-dev \
-    libsndfile1-dev \
-    ffmpeg \
+      python3.11 \
+      bzip2 \
+      curl \
+      git \
+      git-lfs \
+      tar \
+      libsndfile1 \
+      libprotobuf23 \
+      libgomp1 \
+      ffmpeg \
     && apt-get clean autoremove --yes \
-    && rm -rf /var/lib/{apt,dpkg,cache,log}
-
-# Copying only necessary files as filtered by .dockerignore
-COPY . .
+    && rm -rf /var/lib/apt/lists/*
 
 # Set Python 3.11 as the default python version
 RUN update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.11 1 && \
     ln -sf /usr/bin/python3.11 /usr/bin/python
 
-# Install pip from source
-RUN curl -O https://bootstrap.pypa.io/get-pip.py && \
-    python get-pip.py && \
-    rm get-pip.py
-
-# Upgrade pip
-RUN pip install --no-cache-dir --upgrade pip
-
-# Install wheel and setuptools
-RUN pip install --no-cache-dir --upgrade pip ".[torch,st,diffusers]"
+# The venv is the only thing carried over from the builder
+COPY --from=builder /opt/venv /opt/venv
+ENV PATH="/opt/venv/bin:$PATH"
 
 # Copy application
 COPY src/huggingface_inference_toolkit huggingface_inference_toolkit

--- a/requirements-torch-cpu.txt
+++ b/requirements-torch-cpu.txt
@@ -1,0 +1,12 @@
+# CPU flavour of requirements-torch.txt, selected with
+# --build-arg TORCH_REQUIREMENTS=requirements-torch-cpu.txt. The default wheels bundle the CUDA
+# runtime and account for most of the image size.
+#
+# torchvision / torchaudio are pinned here, unlike in requirements-torch.txt: the +cpu builds have
+# to match torch exactly, and this index would otherwise resolve a pair built against another one.
+--extra-index-url https://download.pytorch.org/whl/cpu
+
+torch==2.5.1+cpu
+torchvision==0.20.1+cpu
+torchaudio==2.5.1+cpu
+peft==0.15.1

--- a/requirements-torch.txt
+++ b/requirements-torch.txt
@@ -1,0 +1,9 @@
+# The `torch` extra. Single source: setup.py reads this into extras["torch"], and the image builder
+# installs it directly. Select the CPU flavour with --build-arg TORCH_REQUIREMENTS=requirements-torch-cpu.txt.
+#
+# Includes `peft` because PEFT requires torch: keeping it here rather than in the core set means
+# torch is not installed unless this extra is asked for.
+torch==2.5.1
+torchvision
+torchaudio
+peft==0.15.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,27 @@
+# Core runtime dependencies. Single source: setup.py reads this into install_requires, and the
+# image builder installs it directly so the heavy downloads land in a layer that a source change
+# does not invalidate.
+#
+# Deliberately torch-free: the inf2 image installs torch-neuronx through optimum-neuron and picks
+# up `.[st]` on top, so torch lives in requirements-torch.txt as the `torch` extra instead.
+
+# Due to an error affecting kenlm and cmake (see https://github.com/kpu/kenlm/pull/464)
+# Also see the transformers patch for it https://github.com/huggingface/transformers/pull/37091
+kenlm@ git+https://github.com/kpu/kenlm@ba83eafdce6553addd885ed3da461bb0d60f8df7
+transformers[sklearn,sentencepiece,audio,vision]==4.51.3
+huggingface_hub[hf_transfer]==0.30.2
+# vision
+Pillow
+librosa
+# speech + torchaudio
+pyctcdecode>=0.3.0
+phonemizer
+ffmpeg
+# web api
+# Pin >= 1.0.1 to address CVE-2026-48710 (GHSA-86qp-5c8j-p5mr):
+# Host header poisons request.url.path; path-based middleware can be bypassed.
+starlette>=1.0.1
+uvicorn
+pandas
+orjson
+einops

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,23 @@
 from __future__ import absolute_import
 
+from pathlib import Path
+
 from setuptools import find_packages, setup
+
+HERE = Path(__file__).parent
+
+
+def requirements(filename):
+    """
+    Read a pinned requirements file.
+
+    Those files are the single home for the pins: the image builder installs them directly, before
+    the sources are copied, so the heavy downloads sit in a docker layer that a source change does
+    not invalidate. Restating the same pins here would give us two places to keep in sync.
+    """
+    lines = HERE.joinpath(filename).read_text().splitlines()
+    return [line.strip() for line in lines if line.strip() and not line.startswith(("#", "-"))]
+
 
 # We don't declare our dependency on transformers here because we build with
 # different packages for different variants
@@ -12,48 +29,14 @@ VERSION = "0.5.6"
 # ffmpeg: ffmpeg is required for audio processing. On Ubuntu it can be installed as follows: apt install ffmpeg
 # libavcodec-extra : libavcodec-extra  includes additional codecs for ffmpeg
 
-install_requires = [
-    # Due to an error affecting kenlm and cmake (see https://github.com/kpu/kenlm/pull/464)
-    # Also see the transformers patch for it https://github.com/huggingface/transformers/pull/37091
-    "kenlm@git+https://github.com/kpu/kenlm@ba83eafdce6553addd885ed3da461bb0d60f8df7",
-    "transformers[sklearn,sentencepiece,audio,vision]==4.51.3",
-    "huggingface_hub[hf_transfer]==0.30.2",
-    # vision
-    "Pillow",
-    "librosa",
-    # speech + torchaudio
-    "pyctcdecode>=0.3.0",
-    "phonemizer",
-    "ffmpeg",
-    # web api
-    # Pin >= 1.0.1 to address CVE-2026-48710 (GHSA-86qp-5c8j-p5mr):
-    # Host header poisons request.url.path; path-based middleware can be bypassed.
-    "starlette>=1.0.1",
-    "uvicorn",
-    "pandas",
-    "orjson",
-    "einops",
-]
+install_requires = requirements("requirements.txt")
 
 extras = {}
 
 extras["st"] = ["sentence_transformers==4.0.2"]
 extras["diffusers"] = ["diffusers==0.33.1", "accelerate==1.6.0"]
-# Includes `peft` as PEFT requires `torch` so having `peft` as a core dependency
-# means that `torch` will be installed even if the `torch` extra is not specified.
-extras["torch"] = ["torch==2.5.1", "torchvision", "torchaudio", "peft==0.15.1"]
-extras["test"] = [
-    "pytest==7.2.1",
-    "pytest-xdist",
-    "parameterized",
-    "psutil",
-    "datasets",
-    "pytest-sugar",
-    "mock==2.0.0",
-    "docker",
-    "requests",
-    "tenacity",
-]
+extras["torch"] = requirements("requirements-torch.txt")
+extras["test"] = requirements("test-requirements.txt")
 extras["quality"] = ["isort", "ruff"]
 extras["inf2"] = ["optimum-neuron"]
 extras["google"] = ["google-cloud-storage", "crcmod==1.7"]

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,0 +1,12 @@
+# The `test` extra, in a file so the unit-test job can install it inside the runtime image, which
+# ships no setup.py. setup.py reads this file, so this is the single source for those pins.
+pytest==7.2.1
+pytest-xdist
+pytest-sugar
+parameterized
+mock==2.0.0
+psutil
+datasets
+docker
+requests
+tenacity


### PR DESCRIPTION
Going on with the progressive port of `api-inference-mini-fork` onto `main` — packaging and images only, no runtime behaviour change. Sourced from `46fa298` / `8719059`, at **main's current pins** (transformers 4.51.3, torch 2.5.1): no dependency is added, moved or bumped.

## What was wrong

Built in a single stage on a CUDA **devel** base, so `build-essential`, `cmake`, `protobuf-compiler` and the dev headers — needed only to compile kenlm — all shipped to production. And `COPY . .` came *before* the dependency install, so touching any source file invalidated the layer that downloads torch.

`make inference-pytorch-cpu` also only swapped the base image: it installed the same CUDA wheels, so the "CPU" image carried the whole CUDA runtime.

## Measured, CPU target

| | `main` today | this branch |
|---|---|---|
| image size | **7.38 GB** | **2.5 GB** |
| `torch.__version__` | `2.5.1+cu124` | `2.5.1+cpu` |
| `torch.version.cuda` | `12.4` | `None` |
| `gcc` in image | `/usr/bin/gcc` | absent |

Both built and run locally. Most of the delta is the wheels; the rest is the toolchain leaving.

## GPU target

Not measured locally (a GPU build needs both CUDA bases plus the wheel layers, ~20 GB). Its win comes from two things, and notably **not** from the wheels, which stay CUDA:

| base | compressed, amd64 |
|---|---|
| `nvidia/cuda:12.1.0-devel-ubuntu22.04` | 3.89 GB |
| `nvidia/cuda:12.1.0-runtime-ubuntu22.04` | 1.38 GB |

≈2.5 GB less to pull and more than that on disk, plus the toolchain packages no longer shipping. The unit-test job builds this image, so CI exercises it.

## One pin, one home

`setup.py` **reads** the pinned files instead of restating them, so nothing is duplicated:

```
requirements.txt          -> install_requires
requirements-torch.txt    -> extras["torch"]
test-requirements.txt     -> extras["test"]
setup.py                  -> st and diffusers pins live here, and only here
```

`requirements.txt` stays deliberately **torch-free**, because `Dockerfile.inf2` does `pip install ".[st]"` on top of torch-neuronx from optimum-neuron — collapsing torch into the core set the way the fork does would break that image. `requirements-torch-cpu.txt` is the CPU flavour of the torch set, selected with `--build-arg TORCH_REQUIREMENTS`.

The builder installs `requirements.txt` + the selected torch file in one cached layer, then `pip install ".[st,diffusers]"` after the sources land — three small pins that cost nothing to re-resolve, in exchange for not having a fourth file.

`setup.py`'s resolved metadata is identical to before the split (13 core deps, same torch/st/diffusers/test extras).

## Verified

Inside the new CPU image: `torch`, `transformers`, `sentence_transformers`, `diffusers`, `kenlm`, `librosa`, `starlette` all import; `huggingface_inference_toolkit` and `webservice_starlette` import (the latter is what gunicorn/uvicorn loads); `gcc` is gone; and a real text-classification inference runs on CPU — `_is_gpu_available()` False, `get_device()` -1, pipeline device `cpu`. Every CUDA-specific branch in the code is behind `device == "cuda"`, including `is_torch_bf16_gpu_available()` in `diffusers_utils`, so a CPU-only wheel takes no special handling.

## Also here

- `unit-test.yaml` mounts `test-requirements.txt` and installs from it instead of `pip install '.[test,st,diffusers,google]'`, which would now fail with "Neither setup.py nor pyproject.toml found". This fix comes from the fork's `cb183b7`; without it in the same PR the unit-test job goes red the moment the multi-stage image lands.
- `Dockerfile.inf2` is untouched and still builds from `setup.py`.