### PR TITLE
feat: add IGNORE_CUSTOM_HANDLER and deployment-wide diffusers defaults

### DIFF
--- a/src/huggingface_inference_toolkit/diffusers_utils.py
+++ b/src/huggingface_inference_toolkit/diffusers_utils.py
@@ -1,4 +1,5 @@
 import importlib.util
+import os
 from typing import Union
 
 from transformers.utils.import_utils import is_torch_bf16_gpu_available
@@ -10,6 +11,24 @@ _diffusers = importlib.util.find_spec("diffusers") is not None
 
 def is_diffusers_available():
     return _diffusers
+
+
+def _generation_default(name, cast):
+    """
+    Read a deployment-wide default for a generation parameter, once, at import.
+
+    Parsing here rather than per request means a meaningless value fails the worker at startup,
+    where it is attributable to the rollout that introduced it. Deferring it to `__call__` would
+    turn a configuration mistake into a 400 on every generation instead. `const.py` parses
+    HF_TRUST_REMOTE_CODE the same way.
+    """
+    value = os.environ.get(name)
+    return None if value is None else cast(value)
+
+
+# Both decide how long a generation takes, for deployments that need a predictable cost per request
+DEFAULT_NUM_INFERENCE_STEPS = _generation_default("DEFAULT_NUM_INFERENCE_STEPS", int)
+DEFAULT_GUIDANCE_SCALE = _generation_default("DEFAULT_GUIDANCE_SCALE", float)
 
 
 if is_diffusers_available():
@@ -62,6 +81,13 @@ class IEAutoPipelineForText2Image:
         if "num_images_per_prompt" in kwargs:
             kwargs.pop("num_images_per_prompt")
             logger.warning("Sending num_images_per_prompt > 1 to pipeline is not supported. Using default value 1.")
+
+        # Only when the request does not carry them, so an explicit parameter always wins
+        if "num_inference_steps" not in kwargs and DEFAULT_NUM_INFERENCE_STEPS is not None:
+            kwargs["num_inference_steps"] = DEFAULT_NUM_INFERENCE_STEPS
+
+        if "guidance_scale" not in kwargs and DEFAULT_GUIDANCE_SCALE is not None:
+            kwargs["guidance_scale"] = DEFAULT_GUIDANCE_SCALE
 
         if "target_size" in kwargs:
             kwargs["height"] = kwargs["target_size"].pop("height")

--- a/src/huggingface_inference_toolkit/env_utils.py
+++ b/src/huggingface_inference_toolkit/env_utils.py
@@ -32,3 +32,11 @@ def api_inference_compat() -> bool:
     Read on every call rather than cached at import: tests toggle it, and it costs nothing.
     """
     return strtobool(os.getenv("API_INFERENCE_COMPAT", "false"))
+
+
+def ignore_custom_handler() -> bool:
+    """
+    Whether to ignore a `handler.py` shipped in the model repository and serve the model with the
+    default pipeline instead.
+    """
+    return strtobool(os.getenv("IGNORE_CUSTOM_HANDLER", "false"))

--- a/src/huggingface_inference_toolkit/handler.py
+++ b/src/huggingface_inference_toolkit/handler.py
@@ -3,7 +3,7 @@ from pathlib import Path
 from typing import Any, Dict, Literal, Optional, Union
 
 from huggingface_inference_toolkit.const import HF_TRUST_REMOTE_CODE
-from huggingface_inference_toolkit.env_utils import api_inference_compat
+from huggingface_inference_toolkit.env_utils import api_inference_compat, ignore_custom_handler
 from huggingface_inference_toolkit.logging import logger
 from huggingface_inference_toolkit.sentence_transformers_utils import SENTENCE_TRANSFORMERS_TASKS
 from huggingface_inference_toolkit.utils import (
@@ -255,7 +255,9 @@ def get_inference_handler_either_custom_or_default_handler(model_dir: Path, task
     Returns:
         InferenceHandler: The appropriate inference handler based on the given model directory and task.
     """
-    custom_pipeline = check_and_register_custom_pipeline_from_directory(model_dir)
+    custom_pipeline = (
+        None if ignore_custom_handler() else check_and_register_custom_pipeline_from_directory(model_dir)
+    )
     if custom_pipeline is not None:
         return custom_pipeline
 

--- a/tests/unit/test_env_knobs.py
+++ b/tests/unit/test_env_knobs.py
@@ -1,0 +1,128 @@
+from types import SimpleNamespace
+
+import pytest
+
+from huggingface_inference_toolkit import diffusers_utils
+from huggingface_inference_toolkit import handler as handler_module
+from huggingface_inference_toolkit.diffusers_utils import IEAutoPipelineForText2Image, _generation_default
+from huggingface_inference_toolkit.env_utils import ignore_custom_handler
+from huggingface_inference_toolkit.handler import get_inference_handler_either_custom_or_default_handler
+
+
+@pytest.mark.parametrize(
+    "value,expected",
+    [(None, False), ("false", False), ("0", False), ("true", True), ("1", True), ("YES", True)],
+)
+def test_ignore_custom_handler_env(monkeypatch, value, expected):
+    if value is None:
+        monkeypatch.delenv("IGNORE_CUSTOM_HANDLER", raising=False)
+    else:
+        monkeypatch.setenv("IGNORE_CUSTOM_HANDLER", value)
+    assert ignore_custom_handler() is expected
+
+
+@pytest.fixture
+def repo_with_a_custom_handler(monkeypatch):
+    """A model directory whose handler.py would be picked up, and a stand-in default handler."""
+    looked = []
+
+    def register(model_dir):
+        looked.append(model_dir)
+        return "custom handler"
+
+    monkeypatch.setattr(handler_module, "check_and_register_custom_pipeline_from_directory", register)
+    monkeypatch.setattr(handler_module, "HuggingFaceHandler", lambda model_dir, task: "default handler")
+    monkeypatch.delenv("AIP_MODE", raising=False)
+    return looked
+
+
+def test_custom_handler_is_used_by_default(monkeypatch, repo_with_a_custom_handler):
+    monkeypatch.delenv("IGNORE_CUSTOM_HANDLER", raising=False)
+
+    assert get_inference_handler_either_custom_or_default_handler("/model", task="text-classification") == (
+        "custom handler"
+    )
+    assert repo_with_a_custom_handler == ["/model"]
+
+
+def test_custom_handler_is_skipped_when_ignored(monkeypatch, repo_with_a_custom_handler):
+    monkeypatch.setenv("IGNORE_CUSTOM_HANDLER", "1")
+
+    assert get_inference_handler_either_custom_or_default_handler("/model", task="text-classification") == (
+        "default handler"
+    )
+    # not even looked for: importing a repo's handler.py executes its module-level code
+    assert repo_with_a_custom_handler == []
+
+
+class FakeDiffusionPipeline:
+    def __init__(self):
+        self.calls = []
+
+    def __call__(self, prompt, **kwargs):
+        self.calls.append(kwargs)
+        return SimpleNamespace(images=["an image"])
+
+
+@pytest.fixture
+def text2image():
+    # bypass __init__, which would load a diffusion model
+    pipeline = IEAutoPipelineForText2Image.__new__(IEAutoPipelineForText2Image)
+    pipeline.pipeline = FakeDiffusionPipeline()
+    return pipeline
+
+
+def test_generation_defaults_are_applied(monkeypatch, text2image):
+    monkeypatch.setattr(diffusers_utils, "DEFAULT_NUM_INFERENCE_STEPS", 12)
+    monkeypatch.setattr(diffusers_utils, "DEFAULT_GUIDANCE_SCALE", 3.5)
+
+    assert text2image("a prompt") == "an image"
+    assert text2image.pipeline.calls[0]["num_inference_steps"] == 12
+    assert text2image.pipeline.calls[0]["guidance_scale"] == 3.5
+
+
+def test_request_parameters_win_over_the_defaults(monkeypatch, text2image):
+    monkeypatch.setattr(diffusers_utils, "DEFAULT_NUM_INFERENCE_STEPS", 12)
+    monkeypatch.setattr(diffusers_utils, "DEFAULT_GUIDANCE_SCALE", 3.5)
+
+    text2image("a prompt", num_inference_steps=40, guidance_scale=9.0)
+
+    assert text2image.pipeline.calls[0]["num_inference_steps"] == 40
+    assert text2image.pipeline.calls[0]["guidance_scale"] == 9.0
+
+
+def test_nothing_is_injected_without_the_env(monkeypatch, text2image):
+    monkeypatch.setattr(diffusers_utils, "DEFAULT_NUM_INFERENCE_STEPS", None)
+    monkeypatch.setattr(diffusers_utils, "DEFAULT_GUIDANCE_SCALE", None)
+
+    text2image("a prompt")
+
+    assert "num_inference_steps" not in text2image.pipeline.calls[0]
+    assert "guidance_scale" not in text2image.pipeline.calls[0]
+
+
+def test_a_zero_guidance_scale_is_honoured(monkeypatch, text2image):
+    # 0 disables classifier-free guidance, so it must not be treated as "unset"
+    monkeypatch.setattr(diffusers_utils, "DEFAULT_GUIDANCE_SCALE", 0.0)
+
+    text2image("a prompt")
+
+    assert text2image.pipeline.calls[0]["guidance_scale"] == 0.0
+
+
+@pytest.mark.parametrize("value,expected", [(None, None), ("12", 12), ("0", 0)])
+def test_generation_default_parsing(monkeypatch, value, expected):
+    if value is None:
+        monkeypatch.delenv("A_DEFAULT", raising=False)
+    else:
+        monkeypatch.setenv("A_DEFAULT", value)
+    assert _generation_default("A_DEFAULT", int) == expected
+
+
+@pytest.mark.parametrize("value", ["", "abc"])
+def test_a_meaningless_default_fails_at_import_not_per_request(monkeypatch, value):
+    # Parsed at module import, so a bad value takes the worker down at startup, where it is
+    # attributable to the rollout — instead of 400ing every generation from inside __call__.
+    monkeypatch.setenv("A_DEFAULT", value)
+    with pytest.raises(ValueError):
+        _generation_default("A_DEFAULT", float)


### PR DESCRIPTION
The last two leaf knobs from `api-inference-mini-fork` (part of `011672a`), sourced from `46fa298`. Both inert unless set.

## `IGNORE_CUSTOM_HANDLER=1`

Serve a model with the default pipeline even when its repository ships a `handler.py`.

It doesn't load the custom handler and discard it — it never looks for it. Registering a repo handler *imports* the module, which executes whatever sits at its top level, so "ignore" has to mean "don't go there at all". A test asserts the lookup isn't attempted.

## `DEFAULT_NUM_INFERENCE_STEPS` / `DEFAULT_GUIDANCE_SCALE`

A deployment-wide default for the two text-to-image parameters that decide how long a generation takes, for setups needing a predictable cost per request. Applied only when the request doesn't carry them, so an explicit request parameter always wins.

## Difference from the fork: where a bad value fails

The fork reads and converts both env vars **inside `__call__`**:

```python
if "guidance_scale" not in kwargs:
    guidance_scale = os.environ.get("DEFAULT_GUIDANCE_SCALE")
    if guidance_scale is not None:        # "" -> float("") -> ValueError, on every request
        kwargs["guidance_scale"] = float(guidance_scale)
```

They are now parsed once at import, beside `is_diffusers_available`:

```python
def _generation_default(name, cast):
    value = os.environ.get(name)
    return None if value is None else cast(value)


DEFAULT_NUM_INFERENCE_STEPS = _generation_default("DEFAULT_NUM_INFERENCE_STEPS", int)
DEFAULT_GUIDANCE_SCALE = _generation_default("DEFAULT_GUIDANCE_SCALE", float)
```

| `DEFAULT_GUIDANCE_SCALE=` | fork | here |
|---|---|---|
| `"7.5"` | applied | applied |
| `"0"` | applied | applied (`0.0 is not None`) |
| `""` | `ValueError` per request → 400 on **every** generation | `ValueError` at import → worker won't boot |
| `"abc"` | `ValueError` per request | `ValueError` at import |
| unset | ignored | ignored |

A meaningless value still fails, which is the point — it just fails at startup, where it's attributable to the rollout that introduced it, instead of surfacing hours later as a mystery 400 from inside the request path. `const.py` already parses `HF_TRUST_REMOTE_CODE` this way. It also drops two `os.environ` reads per request.

## Tests

`tests/unit/test_env_knobs.py`, 17 cases: env parsing for the flag, the custom-handler lookup being skipped (and used by default), defaults applied, request parameters winning, nothing injected when unset, `0` honoured, and the parsing itself — including that `""` and `"abc"` raise. No model download; the diffusers pipeline is driven through a fake.

`ruff check src tests` clean.

## Rebased onto main

Rebased on top of #131 and #132. The `env_utils.py` overlap I flagged (both PRs appended an accessor) is resolved, as is the `handler.py` import — `api_inference_compat` and `ignore_custom_handler` now come in on one line. Fast-forward on `main`.