### PR TITLE
feat: shed load when inference latency drifts above its own baseline

### DIFF
--- a/src/huggingface_inference_toolkit/handler.py
+++ b/src/huggingface_inference_toolkit/handler.py
@@ -1,9 +1,11 @@
 import os
 from pathlib import Path
+from time import perf_counter
 from typing import Any, Dict, Literal, Optional, Union
 
 from huggingface_inference_toolkit.const import HF_TRUST_REMOTE_CODE
 from huggingface_inference_toolkit.env_utils import api_inference_compat, ignore_custom_handler
+from huggingface_inference_toolkit.latency_guard import latency_guard
 from huggingface_inference_toolkit.logging import logger
 from huggingface_inference_toolkit.sentence_transformers_utils import SENTENCE_TRANSFORMERS_TASKS
 from huggingface_inference_toolkit.utils import (
@@ -35,6 +37,16 @@ class HuggingFaceHandler:
             :data: (obj): the raw request body data.
         :return: prediction output
         """
+        start = perf_counter()
+        pred = self._timed_call(data)
+        duration = perf_counter() - start
+        logger.info("Inference duration: %.2f ms", duration * 1000)
+        # Only the model call is timed, so the guard's baseline does not move with deserialization,
+        # queueing or serialization
+        latency_guard.record(duration)
+        return pred
+
+    def _timed_call(self, data: Dict[str, Any]) -> Dict[str, Any]:
         inputs = data.pop("inputs", data)
         parameters = data.pop("parameters", {})
 

--- a/src/huggingface_inference_toolkit/latency_guard.py
+++ b/src/huggingface_inference_toolkit/latency_guard.py
@@ -1,0 +1,87 @@
+import os
+import time
+
+from huggingface_inference_toolkit.logging import logger
+
+ENABLED = os.getenv("LATENCY_GUARD_ENABLED", "0").lower() in ("1", "true")
+
+# How many inference calls to observe before activating the guard
+WARMUP_REQUESTS = int(os.getenv("LATENCY_WARMUP_REQUESTS", "10"))
+# EMA alpha for the fast (recent) window — ~3-5 requests
+FAST_ALPHA = float(os.getenv("LATENCY_FAST_ALPHA", "0.3"))
+# EMA alpha for the slow (baseline) window — ~20 requests
+SLOW_ALPHA = float(os.getenv("LATENCY_SLOW_ALPHA", "0.05"))
+# Auto-freeze when fast_ema > OVERLOAD_FACTOR * slow_ema
+OVERLOAD_FACTOR = float(os.getenv("LATENCY_OVERLOAD_FACTOR", "3.0"))
+# Auto-unfreeze when fast_ema < RECOVERY_FACTOR * slow_ema (hysteresis: < OVERLOAD_FACTOR)
+RECOVERY_FACTOR = float(os.getenv("LATENCY_RECOVERY_FACTOR", "1.5"))
+# How long we stay frozen before letting requests through again to re-measure latency
+FREEZE_SECONDS = float(os.getenv("LATENCY_FREEZE_SECONDS", "10"))
+
+
+class LatencyGuard:
+    """
+    Tracks pure inference latency via a dual EMA and auto-freezes new request
+    acceptance when recent latency drifts too far above the learned baseline.
+
+    Freezing is time bounded: a frozen worker runs no inference, so it records no
+    new latency either and could never unfreeze on its own. After FREEZE_SECONDS we
+    accept requests again ("half open") to get fresh samples, and either unfreeze for
+    good once latency is back to the baseline, or freeze again for another round.
+    """
+
+    def __init__(self):
+        self._fast_ema = None
+        self._slow_ema = None
+        self._warmup_count = 0
+        self._auto_frozen = False
+        self._frozen_at = 0.0
+
+    def record(self, duration_s: float):
+        """Called after each inference with its wall-clock duration in seconds. No-op if disabled."""
+        if not ENABLED:
+            return
+        if self._fast_ema is None:
+            self._fast_ema = duration_s
+            self._slow_ema = duration_s
+        else:
+            self._fast_ema = FAST_ALPHA * duration_s + (1 - FAST_ALPHA) * self._fast_ema
+            # Stop updating the baseline while auto-frozen so it doesn't drift up
+            if not self._auto_frozen:
+                self._slow_ema = SLOW_ALPHA * duration_s + (1 - SLOW_ALPHA) * self._slow_ema
+
+        self._warmup_count += 1
+        if self._warmup_count <= WARMUP_REQUESTS:
+            return
+
+        ratio = self._fast_ema / self._slow_ema
+        if not self._auto_frozen and ratio > OVERLOAD_FACTOR:
+            logger.warning(
+                "LatencyGuard: auto-freezing — fast_ema=%.1fms slow_ema=%.1fms ratio=%.2f",
+                self._fast_ema * 1000, self._slow_ema * 1000, ratio,
+            )
+            self._auto_frozen = True
+            self._frozen_at = time.monotonic()
+        elif self._auto_frozen and ratio < RECOVERY_FACTOR:
+            logger.info(
+                "LatencyGuard: auto-unfreezing — fast_ema=%.1fms slow_ema=%.1fms ratio=%.2f",
+                self._fast_ema * 1000, self._slow_ema * 1000, ratio,
+            )
+            self._auto_frozen = False
+        elif self._auto_frozen and ratio > OVERLOAD_FACTOR:
+            # Still overloaded on the half open probe: freeze for another round
+            self._frozen_at = time.monotonic()
+
+    @property
+    def accepting(self) -> bool:
+        if not ENABLED or not self._auto_frozen:
+            return True
+        # Half open: let requests through again so that fresh latency samples can be recorded
+        return time.monotonic() - self._frozen_at >= FREEZE_SECONDS
+
+    @property
+    def auto_frozen(self) -> bool:
+        return self._auto_frozen
+
+
+latency_guard = LatencyGuard()

--- a/src/huggingface_inference_toolkit/webservice_starlette.py
+++ b/src/huggingface_inference_toolkit/webservice_starlette.py
@@ -21,6 +21,7 @@ from huggingface_inference_toolkit.const import (
 from huggingface_inference_toolkit.handler import (
     get_inference_handler_either_custom_or_default_handler,
 )
+from huggingface_inference_toolkit.latency_guard import latency_guard
 from huggingface_inference_toolkit.logging import logger
 from huggingface_inference_toolkit.serialization.base import ContentType
 from huggingface_inference_toolkit.serialization.json_utils import Jsoner
@@ -84,16 +85,29 @@ async def health(request):
 # Report Prometheus metrics
 # inf_batch_current_size: Current number of requests being processed
 # inf_queue_size: Number of requests waiting in the queue
+# inf_accepting: Whether new requests are being accepted (0 while shedding load)
+# inf_auto_frozen: Whether the latency guard considers this worker overloaded
 async def metrics(request):
     batch_current_size = MAX_CONCURRENT_THREADS - MAX_THREADS_GUARD.value
     queue_size = MAX_THREADS_GUARD.statistics().tasks_waiting
     return PlainTextResponse(
         f"inf_batch_current_size {batch_current_size}\n" +
         f"inf_queue_size {queue_size}\n"
+        f"inf_accepting {int(latency_guard.accepting)}\n"
+        f"inf_auto_frozen {int(latency_guard.auto_frozen)}\n"
     )
 
 
 async def predict(request):
+    # Shed load before reading the body: a worker whose latency has drifted far above its baseline
+    # is better off refusing quickly than queueing work its callers will time out on.
+    if not latency_guard.accepting:
+        return Response(
+            Jsoner.serialize({"error": "Service temporarily unavailable, overload detected"}),
+            status_code=503,
+            media_type="application/json",
+        )
+
     try:
         # extracts content from request
         content_type = request.headers.get("content-Type", os.environ.get("DEFAULT_CONTENT_TYPE", ""))

--- a/tests/unit/test_latency_guard.py
+++ b/tests/unit/test_latency_guard.py
@@ -1,0 +1,138 @@
+import pytest
+
+from huggingface_inference_toolkit import latency_guard as guard_module
+from huggingface_inference_toolkit.latency_guard import LatencyGuard
+
+BASELINE = 0.1  # a normal inference, in seconds
+OVERLOADED = 5.0  # what one looks like when the node is thrashing
+
+
+@pytest.fixture
+def clock(monkeypatch):
+    """A monotonic clock we drive by hand, so freeze windows don't depend on wall time."""
+    now = [1000.0]
+    monkeypatch.setattr(guard_module.time, "monotonic", lambda: now[0])
+    return now
+
+
+@pytest.fixture
+def enabled(monkeypatch):
+    monkeypatch.setattr(guard_module, "ENABLED", True)
+
+
+def feed(guard, duration, times=1):
+    for _ in range(times):
+        guard.record(duration)
+
+
+def warmed_up(guard):
+    """Past the warmup window with a stable baseline, so the guard is armed."""
+    feed(guard, BASELINE, guard_module.WARMUP_REQUESTS + 1)
+    return guard
+
+
+def test_disabled_by_default(clock, monkeypatch):
+    monkeypatch.setattr(guard_module, "ENABLED", False)
+    guard = warmed_up(LatencyGuard())
+
+    feed(guard, OVERLOADED, 5)
+
+    assert guard.accepting is True
+    assert guard.auto_frozen is False
+
+
+def test_does_not_freeze_during_warmup(clock, enabled):
+    guard = LatencyGuard()
+
+    # slow from the very first request: there is no baseline to compare against yet
+    feed(guard, OVERLOADED, guard_module.WARMUP_REQUESTS)
+
+    assert guard.accepting is True
+    assert guard.auto_frozen is False
+
+
+def test_freezes_when_latency_drifts_above_the_baseline(clock, enabled):
+    guard = warmed_up(LatencyGuard())
+    assert guard.accepting is True
+
+    feed(guard, OVERLOADED)
+
+    assert guard.auto_frozen is True
+    assert guard.accepting is False
+
+
+def test_half_opens_after_the_freeze_window(clock, enabled):
+    guard = warmed_up(LatencyGuard())
+    feed(guard, OVERLOADED)
+    assert guard.accepting is False
+
+    clock[0] += guard_module.FREEZE_SECONDS - 0.01
+    assert guard.accepting is False
+
+    clock[0] += 0.02
+    # still considered overloaded, but requests are let through to get fresh samples — without this
+    # the guard could never recover: a frozen worker runs no inference, so it records no latency
+    assert guard.accepting is True
+    assert guard.auto_frozen is True
+
+
+def test_unfreezes_once_latency_is_back_to_the_baseline(clock, enabled):
+    guard = warmed_up(LatencyGuard())
+    feed(guard, OVERLOADED)
+    clock[0] += guard_module.FREEZE_SECONDS
+
+    feed(guard, BASELINE, 5)
+
+    assert guard.auto_frozen is False
+    assert guard.accepting is True
+
+
+def test_freezes_again_when_the_probe_is_still_slow(clock, enabled):
+    guard = warmed_up(LatencyGuard())
+    feed(guard, OVERLOADED)
+    clock[0] += guard_module.FREEZE_SECONDS
+    assert guard.accepting is True  # half open
+
+    feed(guard, OVERLOADED)
+
+    # the window restarts rather than staying open
+    assert guard.accepting is False
+    clock[0] += guard_module.FREEZE_SECONDS
+    assert guard.accepting is True
+
+
+def test_the_baseline_stops_moving_once_frozen(clock, enabled):
+    guard = warmed_up(LatencyGuard())
+
+    # the sample that trips the freeze is recorded while still unfrozen, so it does move the
+    # baseline; everything after it must not
+    feed(guard, OVERLOADED)
+    assert guard.auto_frozen is True
+    baseline_while_frozen = guard._slow_ema
+
+    feed(guard, OVERLOADED, 10)
+
+    # otherwise a long overload would teach the guard that slow is normal, and it would stop firing
+    assert guard._slow_ema == baseline_while_frozen
+
+
+class FakePipeline:
+    task = "text-classification"
+
+    def __call__(self, inputs, **parameters):
+        return [{"label": "A", "score": 1.0}]
+
+
+def test_the_handler_reports_its_inference_duration(monkeypatch):
+    """The wiring: whatever the handler measures is what the guard learns from."""
+    from huggingface_inference_toolkit.handler import HuggingFaceHandler
+
+    recorded = []
+    monkeypatch.setattr(guard_module.latency_guard, "record", recorded.append)
+
+    handler = HuggingFaceHandler.__new__(HuggingFaceHandler)  # bypass __init__, no model to load
+    handler.pipeline = FakePipeline()
+
+    assert handler({"inputs": "x"}) == [{"label": "A", "score": 1.0}]
+    assert len(recorded) == 1
+    assert recorded[0] >= 0


### PR DESCRIPTION
`LATENCY_GUARD_ENABLED=1` tracks pure inference latency with two EMAs — a fast one over the last few requests, a slow one as the learned baseline — and answers `503` while the fast one sits far above the slow one. **Off by default.**

The idea is to refuse quickly instead of queueing work whose callers will have timed out by the time it runs, and to do that without a fixed latency threshold: what counts as "slow" depends entirely on the model, so the guard learns it from the worker's own history. Only the model call is timed, so the baseline doesn't move with deserialization, queueing or serialization.

Two gauges join `/metrics`: `inf_accepting`, `inf_auto_frozen`.

| env var | default | |
|---|---|---|
| `LATENCY_GUARD_ENABLED` | `0` | off unless set |
| `LATENCY_WARMUP_REQUESTS` | `10` | observations before the guard can fire |
| `LATENCY_FAST_ALPHA` / `LATENCY_SLOW_ALPHA` | `0.3` / `0.05` | ~3-5 vs ~20 request windows |
| `LATENCY_OVERLOAD_FACTOR` | `3.0` | freeze when fast > 3× baseline |
| `LATENCY_RECOVERY_FACTOR` | `1.5` | unfreeze below 1.5× (hysteresis) |
| `LATENCY_FREEZE_SECONDS` | `10` | how long before re-probing |

## The fix that has to come with it

`ddc8b5c` alone is broken, and the fork fixed it later in `cb183b7`. Without that fix the freeze is unbounded, and it deadlocks by construction:

> a frozen worker rejects every request → it runs no inference → it records no latency → the fast EMA it needs in order to recover never moves again

So the first freeze would be permanent for the life of the process. `LATENCY_FREEZE_SECONDS` makes it a half-open window: after it elapses, requests are let through to get fresh samples, and the guard either unfreezes for good or freezes for another round. A test pins the window opening at exactly that boundary.

The baseline also stops updating while frozen — otherwise a sustained overload would teach the guard that slow is normal and quietly disable it. Also tested.

## Tests

`tests/unit/test_latency_guard.py`, 8 cases, driven with a hand-held monotonic clock so no test depends on wall time: disabled by default, no freeze during warmup, freeze on drift, the half-open boundary, recovery, re-freeze when the probe is still slow, baseline frozen while frozen, and the handler reporting its duration to the guard.

Not covered: the `503` itself at HTTP level. It's five lines gated on `latency_guard.accepting`, and exercising it needs the app's lifespan to load a model.

`ruff check src tests` clean. The 10 other failures in `tests/unit` locally are pre-existing — missing `sentence_transformers`, `diffusers`, `google-cloud-storage` — verified as an identical set with and without this change by stashing it.
