### PR TITLE
fix(serialization): map the accept media type to a PIL format name

### DIFF
--- a/src/huggingface_inference_toolkit/serialization/image_utils.py
+++ b/src/huggingface_inference_toolkit/serialization/image_utils.py
@@ -2,6 +2,25 @@ from io import BytesIO
 
 from PIL import Image
 
+# A media type is not a PIL format name. PIL registers "JPEG", never "JPG", and `image/x-image`
+# names no format at all, so deriving the format from the subtype produced a `KeyError` for two
+# of the types we advertise as supported. Keys are bare, lowercased media types, which is what
+# `ContentType.resolve_accept` hands back.
+MEDIA_TYPE_TO_PIL_FORMAT = {
+    "image/png": "PNG",
+    "image/jpeg": "JPEG",
+    "image/jpg": "JPEG",
+    "image/tiff": "TIFF",
+    "image/bmp": "BMP",
+    "image/gif": "GIF",
+    "image/webp": "WEBP",
+    # Not a real format: it means "an image", so answer with the lossless one.
+    "image/x-image": "PNG",
+}
+
+# JPEG has no alpha channel and no palette, so PIL refuses those modes outright.
+_JPEG_SAFE_MODES = {"RGB", "L", "CMYK"}
+
 
 class Imager:
     @staticmethod
@@ -11,10 +30,24 @@ class Imager:
 
     @staticmethod
     def serialize(image, accept=None):
-        if isinstance(image, Image.Image):
-            img_byte_arr = BytesIO()
-            image.save(img_byte_arr, format=accept.split("/")[-1].upper())
-            img_byte_arr = img_byte_arr.getvalue()
-            return img_byte_arr
-        else:
+        if not isinstance(image, Image.Image):
             raise ValueError(f"Can only serialize PIL.Image.Image, got {type(image)}")
+
+        # `accept` reaches us already resolved to a bare media type, but tolerate a raw header
+        # so a direct caller is not silently given the wrong format.
+        media_type = (accept or "image/png").split(";")[0].strip().lower()
+        if media_type not in MEDIA_TYPE_TO_PIL_FORMAT:
+            raise ValueError(
+                f'Cannot serialize an image as "{accept}". Supported types are: '
+                f"{', '.join(MEDIA_TYPE_TO_PIL_FORMAT)}"
+            )
+        image_format = MEDIA_TYPE_TO_PIL_FORMAT[media_type]
+
+        if image_format == "JPEG" and image.mode not in _JPEG_SAFE_MODES:
+            # Masks come back as "P" and generated images can carry alpha; both are valid
+            # answers to a JPEG request, so flatten rather than fail.
+            image = image.convert("RGB")
+
+        img_byte_arr = BytesIO()
+        image.save(img_byte_arr, format=image_format)
+        return img_byte_arr.getvalue()

--- a/tests/unit/test_serialization.py
+++ b/tests/unit/test_serialization.py
@@ -1,8 +1,11 @@
+from io import BytesIO
+
 import pytest
+from PIL import Image
 
 from huggingface_inference_toolkit.serialization.audio_utils import Audioer
-from huggingface_inference_toolkit.serialization.base import ContentType
-from huggingface_inference_toolkit.serialization.image_utils import Imager
+from huggingface_inference_toolkit.serialization.base import ContentType, content_type_mapping
+from huggingface_inference_toolkit.serialization.image_utils import MEDIA_TYPE_TO_PIL_FORMAT, Imager
 from huggingface_inference_toolkit.serialization.json_utils import Jsoner
 
 
@@ -98,3 +101,56 @@ def test_resolve_accept_returns_a_bare_media_type(accept, expected):
 def test_resolve_accept_rejects_when_nothing_is_producible():
     with pytest.raises(Exception, match="not supported"):
         ContentType.resolve_accept("text/html")
+
+
+@pytest.mark.parametrize(
+    "accept,expected_format",
+    [
+        ("image/png", "PNG"),
+        # PIL registers "JPEG", so deriving the format from the subtype raised a KeyError here
+        ("image/jpg", "JPEG"),
+        ("image/jpeg", "JPEG"),
+        ("image/tiff", "TIFF"),
+        ("image/bmp", "BMP"),
+        ("image/gif", "GIF"),
+        ("image/webp", "WEBP"),
+        # Names no format at all: answer with the lossless one
+        ("image/x-image", "PNG"),
+    ],
+)
+def test_imager_serializes_every_supported_accept(accept, expected_format):
+    body = Imager.serialize(Image.new("RGB", (8, 8), "red"), accept)
+    assert Image.open(BytesIO(body)).format == expected_format
+
+
+@pytest.mark.parametrize("accept", ["image/JPG", "image/jpeg;q=0.8", None])
+def test_imager_tolerates_unresolved_accept_values(accept):
+    # `resolve_accept` normally normalizes this, but a direct caller should not get a wrong format
+    assert Image.open(BytesIO(Imager.serialize(Image.new("RGB", (8, 8)), accept))).format in {
+        "JPEG",
+        "PNG",
+    }
+
+
+@pytest.mark.parametrize("mode", ["RGBA", "P", "L"])
+def test_imager_flattens_modes_jpeg_cannot_hold(mode):
+    # Masks arrive as "P" and generated images can carry alpha; JPEG accepts neither
+    body = Imager.serialize(Image.new(mode, (8, 8)), "image/jpeg")
+    assert Image.open(BytesIO(body)).format == "JPEG"
+
+
+def test_imager_rejects_types_it_cannot_produce():
+    with pytest.raises(ValueError, match="Cannot serialize an image"):
+        Imager.serialize(Image.new("RGB", (8, 8)), "application/json")
+
+
+def test_imager_rejects_non_images():
+    with pytest.raises(ValueError, match="Can only serialize"):
+        Imager.serialize({"not": "an image"}, "image/png")
+
+
+def test_every_advertised_image_type_can_be_serialized():
+    # Guard against drift: a new image/* row in `content_type_mapping` that has no PIL format
+    # would only fail at response time, on the accept path
+    advertised = {media_type for media_type in content_type_mapping if media_type.startswith("image/")}
+    assert advertised == set(MEDIA_TYPE_TO_PIL_FORMAT)


### PR DESCRIPTION
Spotted while auditing #129, unrelated to it. Independent of the other two bug fixes opened
alongside this one.

## The bug

`Imager.serialize` derived the PIL format from the media type's subtype:

```python
image.save(img_byte_arr, format=accept.split("/")[-1].upper())
```

A media type subtype is not a PIL format name. Two of the types `content_type_mapping`
advertises as supported therefore failed at response time:

| `Accept` | derived format | result |
| --- | --- | --- |
| `image/jpg` | `"JPG"` | `KeyError` — PIL registers `"JPEG"`, never `"JPG"` |
| `image/x-image` | `"X-IMAGE"` | `KeyError` — names no format at all |

`predict()` wraps the request in `try/except` and returns 400, so asking for a type the
service itself lists as supported failed the request. Verified against Pillow: `JPEG`, `PNG`,
`TIFF`, `BMP`, `GIF` and `WEBP` all save; `JPG` and `X-IMAGE` both raise `KeyError`.

## The fix

An explicit media type -> format mapping. `image/x-image` names no real format and means "an
image", so it answers with the lossless one.

Requesting JPEG was broken for a second reason, which a format-name fix alone would have
left in place: JPEG holds neither an alpha channel nor a palette, so PIL refuses those modes
with `OSError: cannot write mode RGBA as JPEG`. Segmentation masks arrive as mode `"P"` and
generated images can carry alpha — both are reasonable answers to a JPEG request, so they are
flattened to RGB instead of failing.

## Tests

- Every advertised `image/*` type serializes, asserted by reading the format back out of the
  encoded bytes rather than trusting the call not to raise
- `RGBA`, `P` and `L` inputs all produce a JPEG
- Unresolved accept values (`image/JPG`, `image/jpeg;q=0.8`, `None`) still pick a sane format
- A drift guard asserting `content_type_mapping`'s `image/*` rows and the format map agree, so
  a new row cannot reintroduce a failure that only shows up on the accept path

## Not addressed

`Accept: image/png; q=0.9` and `application/json;charset=utf-8` were the same family of
problem on the request path and were already fixed by #130.
