### PR TITLE
fix(utils): coerce float and signed query parameters instead of leaving them strings

### DIFF
--- a/src/huggingface_inference_toolkit/utils.py
+++ b/src/huggingface_inference_toolkit/utils.py
@@ -1,4 +1,5 @@
 import importlib.util
+import math
 import os
 import sys
 from pathlib import Path
@@ -267,16 +268,36 @@ def get_pipeline(
     return hf_pipeline  # type: ignore
 
 
+def _coerce_query_param(value: str):
+    """
+    Coerce one query-string value to the type a pipeline expects, leaving it a string when it is
+    not a number or a boolean.
+
+    `str.isnumeric()` is the wrong test for "is this an int": it is False for `-1` and for any
+    float, so those reached the pipeline as strings, and it is True for characters like `²` and
+    `½`, which `int()` then refuses. Asking `int()` and `float()` directly answers exactly the
+    question we care about.
+    """
+    if value == "true":
+        return True
+    if value == "false":
+        return False
+    try:
+        return int(value)
+    except ValueError:
+        pass
+    try:
+        number = float(value)
+    except ValueError:
+        return value
+    # `float` also accepts "nan", "inf" and "infinity". None of them is a meaningful pipeline
+    # parameter and JSON cannot represent them, so keep those as strings.
+    return number if math.isfinite(number) else value
+
+
 def convert_params_to_int_or_bool(params):
-    """Converts query params to int or bool if possible"""
-    for k, v in params.items():
-        if v.isnumeric():
-            params[k] = int(v)
-        if v == "false":
-            params[k] = False
-        if v == "true":
-            params[k] = True
-    return params
+    """Converts query params to int, float or bool if possible"""
+    return {k: _coerce_query_param(v) for k, v in params.items()}
 
 
 def should_discard_left() -> bool:

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -14,6 +14,7 @@ from huggingface_inference_toolkit.utils import (
     _is_gpu_available,
     _load_repository_from_hf,
     check_and_register_custom_pipeline_from_directory,
+    convert_params_to_int_or_bool,
     get_pipeline,
     should_discard_left,
 )
@@ -272,3 +273,49 @@ def test_safetensors_probe_keeps_bin_weights_when_the_revision_has_no_safetensor
     # no safetensors at this revision, so the .bin weights are the ones that must survive
     assert "pytorch*" not in seen["ignore_patterns"]
     assert "*safetensors" in seen["ignore_patterns"]
+
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        # ints, including the signs `str.isnumeric()` rejects
+        ("5", 5),
+        ("-1", -1),
+        ("+3", 3),
+        ("0", 0),
+        # floats, none of which `str.isnumeric()` accepts
+        ("0.5", 0.5),
+        ("-0.5", -0.5),
+        ("1e3", 1000.0),
+        # booleans
+        ("true", True),
+        ("false", False),
+        # left alone
+        ("hello", "hello"),
+        ("", ""),
+        ("True", "True"),
+        ("1,2", "1,2"),
+        # `str.isnumeric()` is True for these but `int()` refuses them
+        ("\u00b2", "\u00b2"),
+        ("\u00bd", "\u00bd"),
+        # `float()` accepts these; JSON cannot represent them and no pipeline wants them
+        ("nan", "nan"),
+        ("inf", "inf"),
+        ("-infinity", "-infinity"),
+    ],
+)
+def test_convert_params_coerces_query_values(raw, expected):
+    converted = convert_params_to_int_or_bool({"p": raw})["p"]
+    assert converted == expected
+    assert type(converted) is type(expected)
+
+
+def test_convert_params_keeps_every_key():
+    params = {"top_k": "5", "temperature": "0.5", "seed": "-1", "do_sample": "true", "prompt": "hi"}
+    assert convert_params_to_int_or_bool(params) == {
+        "top_k": 5,
+        "temperature": 0.5,
+        "seed": -1,
+        "do_sample": True,
+        "prompt": "hi",
+    }


### PR DESCRIPTION
Spotted while auditing #129, unrelated to it. Independent of the other two bug fixes opened
alongside this one.

## The bug

Query parameters are folded into the request body by `convert_params_to_int_or_bool`, which
used `str.isnumeric()` to decide whether a value was a number:

```python
if v.isnumeric():
    params[k] = int(v)
```

`str.isnumeric()` is not "can this be an int". It is wrong in both directions:

| request | before | why |
| --- | --- | --- |
| `?temperature=0.5` | `"0.5"` (str) | `"0.5".isnumeric()` is False |
| `?seed=-1` | `"-1"` (str) | `"-1".isnumeric()` is False — the sign is not numeric |
| `?top_p=1e3` | `"1e3"` (str) | same |
| `?x=²` | **400** | `"²".isnumeric()` is True, but `int("²")` raises `ValueError` |

The float case is the one that matters in practice: `?temperature=0.5` reaches the pipeline as
the string `"0.5"`. A pipeline that does arithmetic on it raises; one that does not silently
ignores the parameter, which is worse, because the request looks like it succeeded while the
parameter did nothing.

The `²` case fails the whole request with `invalid literal for int() with base 10`.

## The fix

Ask `int()`, then `float()`. That answers the actual question and needs no character-class
reasoning.

`float()` also accepts `"nan"`, `"inf"` and `"infinity"`. JSON cannot represent them and none is
a meaningful pipeline parameter, so they are left as strings rather than silently becoming
floats — a widening the old code did not have and that nothing asked for.

Two secondary cleanups, both consequences of the above rather than separate changes:

- The three `if`s were unconditional, so a value was re-tested after already being converted.
  Now one decision per value.
- It returns a new dict instead of mutating its argument. The only production caller already
  used the return value.

## Tests

Table-driven over ints (`5`, `-1`, `+3`, `0`), floats (`0.5`, `-0.5`, `1e3`), booleans, values
that must stay strings (`hello`, `""`, `True`, `1,2`), the `isnumeric()`-but-not-int characters
`²` and `½`, and the non-finite floats. Asserts the exact type, not just equality, so a bool
cannot pass as an int — `0 == False` in Python.
