### PR TITLE
fix(utils): probe the requested revision for safetensors, not the default branch

### DIFF
--- a/src/huggingface_inference_toolkit/utils.py
+++ b/src/huggingface_inference_toolkit/utils.py
@@ -129,7 +129,10 @@ def _load_repository_from_hf(
 
     # check if safetensors weights are available
     if framework == "pytorch":
-        files = HfApi().model_info(repository_id).siblings
+        # Probe the revision we are about to download, not the default branch: this answer picks
+        # the ignore-patterns below, so asking about a different commit can filter out the only
+        # weights the requested one has.
+        files = HfApi().model_info(repository_id, revision=revision).siblings
         if any(f.rfilename.endswith("safetensors") for f in files):
             framework = "safetensors"
 

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -7,6 +7,7 @@ import pytest
 from transformers.file_utils import is_torch_available
 from transformers.testing_utils import require_tf, require_torch, slow
 
+from huggingface_inference_toolkit import utils as hf_utils
 from huggingface_inference_toolkit.handler import get_inference_handler_either_custom_or_default_handler
 from huggingface_inference_toolkit.utils import (
     _get_framework,
@@ -218,3 +219,56 @@ def test_should_discard_left(monkeypatch, value, expected):
     else:
         monkeypatch.setenv("DISCARD_LEFT", value)
     assert should_discard_left() is expected
+
+
+class _Sibling:
+    def __init__(self, rfilename):
+        self.rfilename = rfilename
+
+
+@pytest.mark.parametrize("revision", ["eb4c77816edd604d0318f8e748a1c606a2888493", None])
+def test_safetensors_probe_asks_about_the_revision_being_downloaded(monkeypatch, tmp_path, revision):
+    # The probe's answer selects the download ignore-patterns, so it has to describe the same
+    # commit snapshot_download will fetch. Querying the default branch instead can filter out the
+    # only weights the requested revision actually has.
+    seen = {}
+
+    class _Info:
+        siblings = [_Sibling("config.json"), _Sibling("model.safetensors")]
+
+    def fake_model_info(self, repo_id, **kwargs):
+        seen["probe_revision"] = kwargs.get("revision")
+        return _Info()
+
+    def fake_snapshot_download(**kwargs):
+        seen["download_revision"] = kwargs.get("revision")
+        seen["ignore_patterns"] = kwargs.get("ignore_patterns")
+
+    monkeypatch.setattr(hf_utils.HfApi, "model_info", fake_model_info)
+    monkeypatch.setattr(hf_utils, "snapshot_download", fake_snapshot_download)
+
+    hf_utils._load_repository_from_hf("some/model", tmp_path, framework="pytorch", revision=revision)
+
+    assert seen["probe_revision"] == revision
+    assert seen["probe_revision"] == seen["download_revision"]
+    # safetensors found at that revision, so the *safetensors filter must not be applied
+    assert "*safetensors" not in seen["ignore_patterns"]
+    assert "pytorch*" in seen["ignore_patterns"]
+
+
+def test_safetensors_probe_keeps_bin_weights_when_the_revision_has_no_safetensors(monkeypatch, tmp_path):
+    seen = {}
+
+    class _Info:
+        siblings = [_Sibling("config.json"), _Sibling("pytorch_model.bin")]
+
+    monkeypatch.setattr(hf_utils.HfApi, "model_info", lambda self, repo_id, **kw: _Info())
+    monkeypatch.setattr(
+        hf_utils, "snapshot_download", lambda **kw: seen.update(ignore_patterns=kw.get("ignore_patterns"))
+    )
+
+    hf_utils._load_repository_from_hf("some/model", tmp_path, framework="pytorch", revision="abc123")
+
+    # no safetensors at this revision, so the .bin weights are the ones that must survive
+    assert "pytorch*" not in seen["ignore_patterns"]
+    assert "*safetensors" in seen["ignore_patterns"]


### PR DESCRIPTION
Spotted while auditing #129, unrelated to it. Independent of the other two bug fixes opened
alongside this one.

## The bug

`_load_repository_from_hf` avoids downloading weights it does not need: it asks the Hub whether
the repo has safetensors, and the answer selects the ignore-patterns passed to
`snapshot_download`.

The probe ignored the revision:

```python
files = HfApi().model_info(repository_id).siblings   # always the default branch
...
snapshot_download(repo_id=repository_id, revision=revision, ignore_patterns=ignore_regex)
```

So the question was asked about the default branch while the download happened at
`HF_REVISION`. When the two differ in weight format, the filter describes files that are not
the ones being fetched:

| default branch | pinned revision | ignore patterns | result |
| --- | --- | --- | --- |
| safetensors | `pytorch_model.bin` only | `pytorch*` added | **the `.bin` weights are skipped — no weights downloaded** |
| `.bin` only | safetensors | `*safetensors` added | the safetensors are skipped |

The first row is the damaging one: the model directory arrives with config and tokenizer but no
weights, and the failure surfaces later as a confusing load error rather than as a download
problem.

## The fix

One argument — `revision=revision` — so the probe and the download describe the same snapshot.
`revision=None` still resolves to the default branch, so nothing changes for unpinned
deployments, which is the common case.

## Tests

Three offline tests, monkeypatching `model_info` and `snapshot_download` rather than hitting the
Hub:

- the revision reaching the probe is the one reaching the download, parametrized over a pinned
  SHA and `None`
- safetensors at that revision means `*safetensors` is not filtered and `pytorch*` is
- no safetensors at that revision means the reverse, which is the case that previously lost the
  weights

Confirmed the first test fails on `main` (`assert None == 'eb4c778...'`) and passes with the
change, so it pins the actual defect rather than just covering the line.
