### PR TITLE
feat: load models lazily, unload idle workers, shut down gracefully

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,6 @@
 .git
 .github
+.hf_cache
 .pytest_cache
 .ruff_cache
 .tox

--- a/.github/workflows/build-container.yaml
+++ b/.github/workflows/build-container.yaml
@@ -20,7 +20,14 @@ jobs:
     with:
       image: inference-pytorch-cpu
       dockerfile: dockerfiles/pytorch/Dockerfile
-      build_args: "BASE_IMAGE=ubuntu:22.04"
+      target: runtime
+      # Same three args the Makefile's CPU target passes. BASE_IMAGE alone is not enough since the
+      # build was split: RUNTIME_IMAGE would keep the CUDA runtime base and TORCH_REQUIREMENTS would
+      # keep the CUDA wheels, so the "cpu" image would ship CUDA.
+      build_args: |
+        BASE_IMAGE=ubuntu:22.04
+        RUNTIME_IMAGE=ubuntu:22.04
+        TORCH_REQUIREMENTS=requirements-torch-cpu.txt
     secrets:
       REGISTRY_USERNAME: ${{ secrets.REGISTRY_USERNAME }}
       REGISTRY_PASSWORD: ${{ secrets.REGISTRY_PASSWORD }}
@@ -29,6 +36,7 @@ jobs:
     with:
       image: inference-pytorch-gpu
       dockerfile: dockerfiles/pytorch/Dockerfile
+      target: runtime
     secrets:
       REGISTRY_USERNAME: ${{ secrets.REGISTRY_USERNAME }}
       REGISTRY_PASSWORD: ${{ secrets.REGISTRY_PASSWORD }}

--- a/.github/workflows/docker-build-action.yaml
+++ b/.github/workflows/docker-build-action.yaml
@@ -20,6 +20,12 @@ on:
         type: string
         required: false
         default: "Dockerfile"
+      # Which Dockerfile stage to publish. Defaults to the single-stage name Dockerfile.inf2 still
+      # uses; the multi-stage pytorch Dockerfile has to ask for "runtime" explicitly.
+      target:
+        type: string
+        required: false
+        default: "base"
     secrets:
       REGISTRY_USERNAME:
         required: true
@@ -55,7 +61,7 @@ jobs:
           push: true
           context: ${{ inputs.context }}
           build-args: ${{ inputs.build_args }}
-          target: base
+          target: ${{ inputs.target }}
           outputs: type=image,compression=zstd,force-compression=true,push=true
           file: ${{ inputs.context }}/${{ inputs.dockerfile }}
           tags: ${{ inputs.repository }}/${{ inputs.image }}:sha-${{ env.GITHUB_SHA_SHORT }},${{ inputs.repository }}/${{ inputs.image }}:latest

--- a/.github/workflows/integration-test-action.yaml
+++ b/.github/workflows/integration-test-action.yaml
@@ -39,15 +39,18 @@ jobs:
       group: ${{ inputs.runs_on }}
     env:
       AWS_REGION: ${{ inputs.region }}
-      # Keep the model cache in the job's own scratch dir, so a run never depends on cache state
-      # it does not own. runner.temp is emptied by the runner at the start and end of every job,
-      # unlike $HOME, which on these long-lived self-hosted runners survives across jobs and would
-      # reintroduce exactly the shared state we are removing here.
+      # Keep the model cache in the job's own workspace, so a run never depends on cache state it
+      # does not own: actions/checkout runs `git clean -ffdx` below, so every job starts from an
+      # empty cache instead of inheriting whatever the previous job on this long-lived self-hosted
+      # runner left under $HOME.
+      # It has to be the workspace rather than runner.temp, tempting as that is: the `runner`
+      # context is not available in a job-level `env:` block, only inside steps, so ${{ runner.temp }}
+      # here makes the whole workflow file invalid.
       # It also has to stay a real path on the runner host: conftest hands the downloaded model dir
       # straight to `docker run -v`, so the docker daemon has to resolve it, not just pytest.
       # Models are re-downloaded every run; the integ fixtures are tiny on purpose.
-      HF_HOME: ${{ runner.temp }}/hf_cache
-      HF_HUB_CACHE: ${{ runner.temp }}/hf_cache/hub
+      HF_HOME: ${{ github.workspace }}/.hf_cache
+      HF_HUB_CACHE: ${{ github.workspace }}/.hf_cache/hub
       RUN_SLOW: ${{ inputs.run_slow }}
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,6 +22,8 @@ ffmpeg
 # Host header poisons request.url.path; path-based middleware can be bypassed.
 starlette>=1.0.1
 uvicorn
+# serves the app; WORKERS relies on it, see scripts/entrypoint.sh
+gunicorn
 pandas
 # Direct import in src/ (embedding serialization), not just a transitive dep
 numpy

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -58,5 +58,13 @@ if [[ ! -z "${HF_MODEL_DIR}" ]]; then
     fi
 fi
 
-# Start the server
-exec uvicorn webservice_starlette:app --host 0.0.0.0 --port ${PORT}
+# Start the server.
+# gunicorn rather than uvicorn directly: WORKERS lets a node host several workers per GPU, which is
+# what makes idle unloading worth it, and --graceful-timeout gives a worker time to finish the
+# inference it is running instead of being killed mid-request (gunicorn's own default is 30s).
+exec gunicorn webservice_starlette:app \
+  -k uvicorn.workers.UvicornWorker \
+  --workers ${WORKERS:-1} \
+  --bind 0.0.0.0:${PORT} \
+  --timeout ${TIMEOUT:-30} \
+  --graceful-timeout ${GRACEFUL_TIMEOUT:-300}

--- a/src/huggingface_inference_toolkit/async_utils.py
+++ b/src/huggingface_inference_toolkit/async_utils.py
@@ -1,5 +1,4 @@
-import functools
-from typing import Any, Callable, Dict, Optional, TypeVar
+from typing import Callable, Optional, TypeVar
 
 import anyio
 from anyio import Semaphore
@@ -18,11 +17,11 @@ P = ParamSpec("P")
 
 # moves blocking call to asyncio threadpool limited to 1 to not overload the system
 # REF: https://stackoverflow.com/a/70929141
-async def async_handler_call(
-    handler: Callable[P, T], body: Dict[str, Any], request: Optional[Request] = None
+async def async_call(
+    handler: Callable[P, T], *args, request: Optional[Request] = None, **kwargs
 ) -> Optional[T]:
     """
-    Run `handler` in the inference threadpool, once a slot is free.
+    Run `handler` in the threadpool, once a slot is free.
 
     When `request` is given, the caller is checked for having left just after the slot is
     acquired, and the call is skipped if it has: under a burst, requests queue here while their
@@ -33,11 +32,13 @@ async def async_handler_call(
     A missed detection only costs us an inference we could have skipped; it never discards a
     request whose caller is still waiting.
     """
+    logger.info("Setting blocking call to async handler")
     async with MAX_THREADS_GUARD:
+        logger.info("Async call semaphore passed")
         if request is not None and await _caller_left(request):
             logger.info("Discarding request as the caller already left")
             return None
-        return await anyio.to_thread.run_sync(functools.partial(handler, body))
+        return await anyio.to_thread.run_sync(handler, *args, **kwargs)
 
 
 async def _caller_left(request: Request) -> bool:

--- a/src/huggingface_inference_toolkit/handler.py
+++ b/src/huggingface_inference_toolkit/handler.py
@@ -3,15 +3,13 @@ from pathlib import Path
 from time import perf_counter
 from typing import Any, Dict, Literal, Optional, Union
 
+from huggingface_inference_toolkit.async_utils import async_call
 from huggingface_inference_toolkit.const import HF_TRUST_REMOTE_CODE
 from huggingface_inference_toolkit.env_utils import api_inference_compat, ignore_custom_handler
 from huggingface_inference_toolkit.latency_guard import latency_guard
 from huggingface_inference_toolkit.logging import logger
 from huggingface_inference_toolkit.sentence_transformers_utils import SENTENCE_TRANSFORMERS_TASKS
-from huggingface_inference_toolkit.utils import (
-    check_and_register_custom_pipeline_from_directory,
-    get_pipeline,
-)
+from huggingface_inference_toolkit.utils import check_and_register_custom_pipeline_from_directory
 
 
 class HuggingFaceHandler:
@@ -20,15 +18,35 @@ class HuggingFaceHandler:
     Transformers, Diffusers, Sentence Transformers and Optimum pipelines.
     """
 
-    def __init__(
-        self, model_dir: Union[str, Path], task: Union[str, None] = None, framework: Literal["pt"] = "pt"
-    ) -> None:
-        self.pipeline = get_pipeline(
-            model_dir=model_dir,  # type: ignore
-            task=task,  # type: ignore
-            framework=framework,
-            trust_remote_code=HF_TRUST_REMOTE_CODE,
+    def __init__(self, pipeline) -> None:
+        self.pipeline = pipeline
+
+    @classmethod
+    async def create(
+        cls,
+        model_dir: Union[str, Path],
+        task: Union[str, None] = None,
+        framework: Literal["pt"] = "pt",
+    ) -> "HuggingFaceHandler":
+        """
+        Build a handler, loading the model off the event loop.
+
+        Construction is async because loading is seconds of blocking work: with the model loaded on
+        first use rather than at startup, doing it inline would stall every other connection on the
+        worker. `heavy_utils` is imported here rather than at module level for the same reason the
+        module exists — an idle worker should not be carrying transformers, diffusers and
+        sentence-transformers in memory.
+        """
+        from huggingface_inference_toolkit.heavy_utils import get_pipeline
+
+        # `anyio.to_thread.run_sync` passes positional arguments only, hence the kwargs dict
+        pipeline = await async_call(
+            get_pipeline,
+            task,  # type: ignore
+            model_dir,  # type: ignore
+            {"framework": framework, "trust_remote_code": HF_TRUST_REMOTE_CODE},
         )
+        return cls(pipeline)
 
     def __call__(self, data: Dict[str, Any]) -> Dict[str, Any]:
         """
@@ -230,11 +248,6 @@ class VertexAIHandler(HuggingFaceHandler):
     Vertex AI specific logic for inference.
     """
 
-    def __init__(
-        self, model_dir: Union[str, Path], task: Union[str, None] = None, framework: Literal["pt"] = "pt"
-    ) -> None:
-        super().__init__(model_dir=model_dir, task=task, framework=framework)
-
     def __call__(self, data: Dict[str, Any]) -> Dict[str, Any]:
         """
         Handles an inference request with input data and makes a prediction.
@@ -256,7 +269,7 @@ class VertexAIHandler(HuggingFaceHandler):
         return {"predictions": predictions}
 
 
-def get_inference_handler_either_custom_or_default_handler(model_dir: Path, task: Optional[str] = None) -> Any:
+async def get_inference_handler_either_custom_or_default_handler(model_dir: Path, task: Optional[str] = None) -> Any:
     """
     Returns the appropriate inference handler based on the given model directory and task.
 
@@ -274,6 +287,6 @@ def get_inference_handler_either_custom_or_default_handler(model_dir: Path, task
         return custom_pipeline
 
     if os.environ.get("AIP_MODE", None) == "PREDICTION":
-        return VertexAIHandler(model_dir=model_dir, task=task)
+        return await VertexAIHandler.create(model_dir=model_dir, task=task)
 
-    return HuggingFaceHandler(model_dir=model_dir, task=task)
+    return await HuggingFaceHandler.create(model_dir=model_dir, task=task)

--- a/src/huggingface_inference_toolkit/heavy_utils.py
+++ b/src/huggingface_inference_toolkit/heavy_utils.py
@@ -1,0 +1,200 @@
+# Heavy because they consume a lot of memory and we want to import them as late as possible to reduce the footprint
+# Transformers / Sentence transformers utils. This module should be imported as late as possible
+# to reduce the memory footprint of a worker: we don't bother handling the uncaching/gc collecting because
+# we want to combine it with idle unload: the gunicorn worker will just suppress itself when unused freeing the memory
+# as wished
+from pathlib import Path
+from time import perf_counter
+from typing import Any, Dict, Optional, Union
+
+from huggingface_hub import HfApi, login, snapshot_download
+from transformers import WhisperForConditionalGeneration, pipeline
+from transformers.file_utils import is_tf_available, is_torch_available
+from transformers.pipelines import Pipeline
+
+from huggingface_inference_toolkit.diffusers_utils import (
+    get_diffusers_pipeline,
+    is_diffusers_available,
+)
+from huggingface_inference_toolkit.logging import logger
+from huggingface_inference_toolkit.optimum_utils import (
+    get_optimum_neuron_pipeline,
+    is_optimum_neuron_available,
+)
+from huggingface_inference_toolkit.sentence_transformers_utils import (
+    get_sentence_transformers_pipeline,
+    is_sentence_transformers_available,
+)
+from huggingface_inference_toolkit.utils import create_artifact_filter
+
+
+def load_repository_from_hf(
+        repository_id: Optional[str] = None,
+        target_dir: Optional[Union[str, Path]] = None,
+        framework: Optional[str] = None,
+        revision: Optional[str] = None,
+        hf_hub_token: Optional[str] = None,
+):
+    """
+    Load a model from huggingface hub.
+    """
+
+    if hf_hub_token is not None:
+        login(token=hf_hub_token)
+
+    if framework is None:
+        framework = _get_framework()
+
+    if isinstance(target_dir, str):
+        target_dir = Path(target_dir)
+
+    # create workdir
+    if not target_dir.exists():
+        target_dir.mkdir(parents=True)
+
+    # check if safetensors weights are available
+    if framework == "pytorch":
+        # Probe the revision we are about to download, not the default branch: this answer picks
+        # the ignore-patterns below, so asking about a different commit can filter out the only
+        # weights the requested one has.
+        files = HfApi().model_info(repository_id, revision=revision).siblings
+        if any(f.rfilename.endswith("safetensors") for f in files):
+            framework = "safetensors"
+
+    # create regex to only include the framework specific weights
+    ignore_regex = create_artifact_filter(framework)
+    logger.info(f"Ignore regex pattern for files, which are not downloaded: {', '.join(ignore_regex)}")
+
+    # Download the repository to the workdir and filter out non-framework
+    # specific weights
+    snapshot_download(
+        repo_id=repository_id,
+        revision=revision,
+        local_dir=str(target_dir),
+        local_dir_use_symlinks=False,
+        ignore_patterns=ignore_regex,
+    )
+
+    return target_dir
+
+
+def get_device():
+    """
+    The get device function will return the device for the DL Framework.
+    """
+    gpu = _is_gpu_available()
+
+    if gpu:
+        return 0
+    else:
+        return -1
+
+
+if is_tf_available():
+    import tensorflow as tf
+
+
+if is_torch_available():
+    import torch
+
+
+def _is_gpu_available():
+    """
+    checks if a gpu is available.
+    """
+    if is_tf_available():
+        return True if len(tf.config.list_physical_devices("GPU")) > 0 else False
+    elif is_torch_available():
+        return torch.cuda.is_available()
+    else:
+        raise RuntimeError(
+            "At least one of TensorFlow 2.0 or PyTorch should be installed. "
+            "To install TensorFlow 2.0, read the instructions at https://www.tensorflow.org/install/ "
+            "To install PyTorch, read the instructions at https://pytorch.org/."
+        )
+
+
+def _get_framework():
+    """
+    extracts which DL framework is used for inference, if both are installed use pytorch
+    """
+
+    if is_torch_available():
+        return "pytorch"
+    elif is_tf_available():
+        return "tensorflow"
+    else:
+        raise RuntimeError(
+            "At least one of TensorFlow 2.0 or PyTorch should be installed. "
+            "To install TensorFlow 2.0, read the instructions at https://www.tensorflow.org/install/ "
+            "To install PyTorch, read the instructions at https://pytorch.org/."
+        )
+
+
+def get_pipeline(
+        task: Union[str, None],
+        model_dir: Path,
+        kwargs: Optional[Dict[str, Any]] = None,
+) -> Pipeline:
+    """
+    create pipeline class for a specific task based on local saved model
+
+    `kwargs` is a dict rather than **kwargs because this runs through
+    `anyio.to_thread.run_sync`, which forwards positional arguments only. It is copied because the
+    pipeline-specific arguments below are added to it.
+    """
+    kwargs = dict(kwargs or {})
+    start = perf_counter()
+    if task is None:
+        raise EnvironmentError(
+            "The task for this model is not set: Please set one: https://huggingface.co/docs#how-is-a-models-type-of-inference-api-and-widget-determined"
+        )
+
+    if task == "conversational":
+        task = "text-generation"
+
+    if is_optimum_neuron_available():
+        logger.info("Using device Neuron")
+        return get_optimum_neuron_pipeline(task=task, model_dir=model_dir)
+
+    device = get_device()
+    logger.info(f"Using device {'GPU' if device == 0 else 'CPU'}")
+
+    # define tokenizer or feature extractor as kwargs to load it the pipeline
+    # correctly
+    if task in {
+        "automatic-speech-recognition",
+        "image-segmentation",
+        "image-classification",
+        "audio-classification",
+        "object-detection",
+        "zero-shot-image-classification",
+    }:
+        kwargs["feature_extractor"] = model_dir
+    elif task not in {"image-text-to-text", "image-to-text", "text-to-image"}:
+        kwargs["tokenizer"] = model_dir
+
+    if is_sentence_transformers_available() and task in [
+        "sentence-similarity",
+        "sentence-embeddings",
+        "sentence-ranking",
+        "text-ranking",
+    ]:
+        if task == "text-ranking":
+            task = "sentence-ranking"
+        hf_pipeline = get_sentence_transformers_pipeline(task=task, model_dir=model_dir, device=device, **kwargs)
+    elif is_diffusers_available() and task == "text-to-image":
+        hf_pipeline = get_diffusers_pipeline(task=task, model_dir=model_dir, device=device, **kwargs)
+    else:
+        hf_pipeline = pipeline(task=task, model=model_dir, device=device, **kwargs)
+
+    if task == "automatic-speech-recognition" and isinstance(hf_pipeline.model, WhisperForConditionalGeneration):
+        # set chunk length to 30s for whisper to enable long audio files
+        hf_pipeline._preprocess_params["chunk_length_s"] = 30
+        hf_pipeline.model.config.forced_decoder_ids = hf_pipeline.tokenizer.get_decoder_prompt_ids(
+            language="english", task="transcribe"
+        )
+
+    end = perf_counter()
+    logger.info("Model pipeline loaded in %.2f ms", (end - start) * 1000)
+    return hf_pipeline  # type: ignore

--- a/src/huggingface_inference_toolkit/idle.py
+++ b/src/huggingface_inference_toolkit/idle.py
@@ -1,0 +1,76 @@
+import asyncio
+import contextlib
+import logging
+import os
+import signal
+import time
+
+from anyio import Semaphore
+
+LOG = logging.getLogger(__name__)
+
+LAST_START = None
+LAST_END = None
+
+UNLOAD_IDLE = os.getenv("UNLOAD_IDLE", "").lower() in ("1", "true")
+IDLE_TIMEOUT = int(os.getenv("IDLE_TIMEOUT", 15))
+
+MAX_REQUESTS = 1000
+REQUEST_COUNTER = Semaphore(MAX_REQUESTS)
+
+
+async def live_check_loop():
+    global LAST_START, LAST_END
+
+    pid = os.getpid()
+
+    LOG.info("Starting live check loop")
+    sleep_time = max(int(IDLE_TIMEOUT // 5), 1)
+
+    while True:
+        await asyncio.sleep(sleep_time)
+        LOG.debug("Checking whether we should unload anything from memory")
+
+        last_start = LAST_START
+        last_end = LAST_END
+
+        LOG.debug("Checking pid %d activity", pid)
+        if not last_start:
+            LOG.debug("No request yet, no need to unload")
+            continue
+
+        if REQUEST_COUNTER.value < MAX_REQUESTS:
+            LOG.info("idle checker: %s requests likely being processed for pid %d, it won't be killed",
+                     MAX_REQUESTS - REQUEST_COUNTER.value, pid)
+            continue
+        if not last_end or last_start >= last_end:
+            LOG.warning("This case should not be possible, semaphore unconsistency ? "
+                        "Request likely being processed for pid %d", pid)
+            continue
+        now = time.time()
+        last_request_age = now - last_end
+        LOG.debug("Pid %d, last request age %s", pid, last_request_age)
+        if last_request_age < IDLE_TIMEOUT:
+            LOG.debug("Model recently active")
+        else:
+            LOG.info("Idle checker: worker inactive for too long. Leaving live check loop")
+            break
+    LOG.info("Aborting this idle worker")
+    os.kill(pid, signal.SIGTERM)
+
+
+@contextlib.asynccontextmanager
+async def request_witnesses():
+    async with REQUEST_COUNTER:
+        LOG.info("Current request count: %s", MAX_REQUESTS - REQUEST_COUNTER.value)
+        global LAST_START, LAST_END
+        LOG.debug("Last request start was %s", LAST_START)
+        LOG.debug("Last request end was %s", LAST_END)
+        # Simple assignment, concurrency safe, no need for any lock
+        LAST_START = time.time()
+        LOG.debug("Current request start timestamp %s", LAST_START)
+        try:
+            yield
+        finally:
+            LAST_END = time.time()
+            LOG.debug("Current request end timestamp %s", LAST_END)

--- a/src/huggingface_inference_toolkit/utils.py
+++ b/src/huggingface_inference_toolkit/utils.py
@@ -3,33 +3,9 @@ import math
 import os
 import sys
 from pathlib import Path
-from typing import Optional, Union
-
-from huggingface_hub import HfApi, login, snapshot_download
-from transformers import WhisperForConditionalGeneration, pipeline
-from transformers.file_utils import is_tf_available, is_torch_available
-from transformers.pipelines import Pipeline
 
 from huggingface_inference_toolkit.const import HF_DEFAULT_PIPELINE_NAME, HF_MODULE_NAME
-from huggingface_inference_toolkit.diffusers_utils import (
-    get_diffusers_pipeline,
-    is_diffusers_available,
-)
 from huggingface_inference_toolkit.logging import logger
-from huggingface_inference_toolkit.optimum_utils import (
-    get_optimum_neuron_pipeline,
-    is_optimum_neuron_available,
-)
-from huggingface_inference_toolkit.sentence_transformers_utils import (
-    get_sentence_transformers_pipeline,
-    is_sentence_transformers_available,
-)
-
-if is_tf_available():
-    import tensorflow as tf
-
-if is_torch_available():
-    import torch
 
 _optimum_available = importlib.util.find_spec("optimum") is not None
 
@@ -69,89 +45,6 @@ def create_artifact_filter(framework):
         return ignore_regex_list
     else:
         return []
-
-
-def _is_gpu_available():
-    """
-    checks if a gpu is available.
-    """
-    if is_tf_available():
-        return True if len(tf.config.list_physical_devices("GPU")) > 0 else False
-    elif is_torch_available():
-        return torch.cuda.is_available()
-    else:
-        raise RuntimeError(
-            "At least one of TensorFlow 2.0 or PyTorch should be installed. "
-            "To install TensorFlow 2.0, read the instructions at https://www.tensorflow.org/install/ "
-            "To install PyTorch, read the instructions at https://pytorch.org/."
-        )
-
-
-def _get_framework():
-    """
-    extracts which DL framework is used for inference, if both are installed use pytorch
-    """
-
-    if is_torch_available():
-        return "pytorch"
-    elif is_tf_available():
-        return "tensorflow"
-    else:
-        raise RuntimeError(
-            "At least one of TensorFlow 2.0 or PyTorch should be installed. "
-            "To install TensorFlow 2.0, read the instructions at https://www.tensorflow.org/install/ "
-            "To install PyTorch, read the instructions at https://pytorch.org/."
-        )
-
-
-def _load_repository_from_hf(
-    repository_id: Optional[str] = None,
-    target_dir: Optional[Union[str, Path]] = None,
-    framework: Optional[str] = None,
-    revision: Optional[str] = None,
-    hf_hub_token: Optional[str] = None,
-):
-    """
-    Load a model from huggingface hub.
-    """
-
-    if hf_hub_token is not None:
-        login(token=hf_hub_token)
-
-    if framework is None:
-        framework = _get_framework()
-
-    if isinstance(target_dir, str):
-        target_dir = Path(target_dir)
-
-    # create workdir
-    if not target_dir.exists():
-        target_dir.mkdir(parents=True)
-
-    # check if safetensors weights are available
-    if framework == "pytorch":
-        # Probe the revision we are about to download, not the default branch: this answer picks
-        # the ignore-patterns below, so asking about a different commit can filter out the only
-        # weights the requested one has.
-        files = HfApi().model_info(repository_id, revision=revision).siblings
-        if any(f.rfilename.endswith("safetensors") for f in files):
-            framework = "safetensors"
-
-    # create regex to only include the framework specific weights
-    ignore_regex = create_artifact_filter(framework)
-    logger.info(f"Ignore regex pattern for files, which are not downloaded: {', '.join(ignore_regex)}")
-
-    # Download the repository to the workdir and filter out non-framework
-    # specific weights
-    snapshot_download(
-        repo_id=repository_id,
-        revision=revision,
-        local_dir=str(target_dir),
-        local_dir_use_symlinks=False,
-        ignore_patterns=ignore_regex,
-    )
-
-    return target_dir
 
 
 def check_and_register_custom_pipeline_from_directory(model_dir):
@@ -194,78 +87,6 @@ def check_and_register_custom_pipeline_from_directory(model_dir):
         logger.info(f"No custom pipeline found at {custom_module}")
         custom_pipeline = None
     return custom_pipeline
-
-
-def get_device():
-    """
-    The get device function will return the device for the DL Framework.
-    """
-    gpu = _is_gpu_available()
-
-    if gpu:
-        return 0
-    else:
-        return -1
-
-
-def get_pipeline(
-    task: Union[str, None],
-    model_dir: Path,
-    **kwargs,
-) -> Pipeline:
-    """
-    create pipeline class for a specific task based on local saved model
-    """
-    if task is None:
-        raise EnvironmentError(
-            "The task for this model is not set: Please set one: https://huggingface.co/docs#how-is-a-models-type-of-inference-api-and-widget-determined"
-        )
-
-    if task == "conversational":
-        task = "text-generation"
-
-    if is_optimum_neuron_available():
-        logger.info("Using device Neuron")
-        return get_optimum_neuron_pipeline(task=task, model_dir=model_dir)
-
-    device = get_device()
-    logger.info(f"Using device {'GPU' if device == 0 else 'CPU'}")
-
-    # define tokenizer or feature extractor as kwargs to load it the pipeline
-    # correctly
-    if task in {
-        "automatic-speech-recognition",
-        "image-segmentation",
-        "image-classification",
-        "audio-classification",
-        "object-detection",
-        "zero-shot-image-classification",
-    }:
-        kwargs["feature_extractor"] = model_dir
-    elif task not in {"image-text-to-text", "image-to-text", "text-to-image"}:
-        kwargs["tokenizer"] = model_dir
-
-    if is_sentence_transformers_available() and task in [
-        "sentence-similarity",
-        "sentence-embeddings",
-        "sentence-ranking",
-        "text-ranking",
-    ]:
-        if task == "text-ranking":
-            task = "sentence-ranking"
-        hf_pipeline = get_sentence_transformers_pipeline(task=task, model_dir=model_dir, device=device, **kwargs)
-    elif is_diffusers_available() and task == "text-to-image":
-        hf_pipeline = get_diffusers_pipeline(task=task, model_dir=model_dir, device=device, **kwargs)
-    else:
-        hf_pipeline = pipeline(task=task, model=model_dir, device=device, **kwargs)
-
-    if task == "automatic-speech-recognition" and isinstance(hf_pipeline.model, WhisperForConditionalGeneration):
-        # set chunk length to 30s for whisper to enable long audio files
-        hf_pipeline._preprocess_params["chunk_length_s"] = 30
-        hf_pipeline.model.config.forced_decoder_ids = hf_pipeline.tokenizer.get_decoder_prompt_ids(
-            language="english", task="transcribe"
-        )
-    return hf_pipeline  # type: ignore
 
 
 def _coerce_query_param(value: str):

--- a/src/huggingface_inference_toolkit/webservice_starlette.py
+++ b/src/huggingface_inference_toolkit/webservice_starlette.py
@@ -1,3 +1,4 @@
+import asyncio
 import base64
 import os
 from contextlib import asynccontextmanager
@@ -5,11 +6,13 @@ from pathlib import Path
 from time import perf_counter
 
 import orjson
+from anyio import Semaphore
 from starlette.applications import Starlette
 from starlette.responses import PlainTextResponse, Response
 from starlette.routing import Route
 
-from huggingface_inference_toolkit.async_utils import MAX_CONCURRENT_THREADS, MAX_THREADS_GUARD, async_handler_call
+from huggingface_inference_toolkit import idle
+from huggingface_inference_toolkit.async_utils import MAX_CONCURRENT_THREADS, MAX_THREADS_GUARD, async_call
 from huggingface_inference_toolkit.const import (
     HF_FRAMEWORK,
     HF_HUB_TOKEN,
@@ -26,20 +29,28 @@ from huggingface_inference_toolkit.logging import logger
 from huggingface_inference_toolkit.serialization.base import ContentType
 from huggingface_inference_toolkit.serialization.json_utils import Jsoner
 from huggingface_inference_toolkit.utils import (
-    _load_repository_from_hf,
     convert_params_to_int_or_bool,
     should_discard_left,
 )
 from huggingface_inference_toolkit.vertex_ai_utils import _load_repository_from_gcs
 
+INFERENCE_HANDLER = None
+INFERENCE_HANDLER_SEMAPHORE = Semaphore(1)
+MODEL_DOWNLOADED = False
+MODEL_DL_SEMAPHORE = Semaphore(1)
 
-async def prepare_model_artifacts():
-    global inference_handler
+
+def download_model():
+    """Fetch the model artifacts if they are not on disk yet. Blocking, so run it in a thread."""
+    global MODEL_DOWNLOADED
+    # imported late: pulling in the hub client drags transformers with it
+    from huggingface_inference_toolkit.heavy_utils import load_repository_from_hf
+
     # 1. check if model artifacts available in HF_MODEL_DIR
     if next(Path(HF_MODEL_DIR).glob("**/*"), None) is None:
         # 2. if not available, try to load from HF_MODEL_ID
         if HF_MODEL_ID is not None:
-            _load_repository_from_hf(
+            load_repository_from_hf(
                 repository_id=HF_MODEL_ID,
                 target_dir=HF_MODEL_DIR,
                 framework=HF_FRAMEWORK,
@@ -60,20 +71,51 @@ async def prepare_model_artifacts():
                 Provided values are:
                 HF_MODEL_DIR: {HF_MODEL_DIR} and HF_MODEL_ID:{HF_MODEL_ID}"""
             )
+    else:
+        logger.info("Model already present in %s", HF_MODEL_DIR)
+    MODEL_DOWNLOADED = True
 
-    logger.info(f"Initializing model from directory:{HF_MODEL_DIR}")
-    # 2. determine correct inference handler
-    inference_handler = get_inference_handler_either_custom_or_default_handler(
-        HF_MODEL_DIR, task=HF_TASK
-    )
-    logger.info("Model initialized successfully")
+
+async def ensure_model_downloaded():
+    if not MODEL_DOWNLOADED:
+        async with MODEL_DL_SEMAPHORE:
+            if not MODEL_DOWNLOADED:
+                await async_call(download_model)
+
+
+async def ensure_handler_loaded():
+    """Load the model on first use, once, even if several requests race for it."""
+    global INFERENCE_HANDLER
+    if INFERENCE_HANDLER is None:
+        async with INFERENCE_HANDLER_SEMAPHORE:
+            if INFERENCE_HANDLER is None:
+                logger.info(f"Initializing model from directory:{HF_MODEL_DIR}")
+                INFERENCE_HANDLER = await get_inference_handler_either_custom_or_default_handler(
+                    HF_MODEL_DIR, task=HF_TASK
+                )
+                logger.info("Model initialized successfully")
+    return INFERENCE_HANDLER
+
+
+async def prepare_model_artifacts():
+    if idle.UNLOAD_IDLE:
+        # Nothing is loaded up front: the worker stays cheap until a request arrives, and the idle
+        # checker terminates it once it goes quiet again, releasing the memory for good.
+        asyncio.create_task(idle.live_check_loop(), name="live_check_loop")
+        logger.info("Idle unloading enabled, deferring model load to the first request")
+        return
+    await ensure_model_downloaded()
+    await ensure_handler_loaded()
 
 
 @asynccontextmanager
 async def lifespan(app):
-    # Starlette 1.0 removed `on_startup` / `on_shutdown` in favor of the
-    # ASGI lifespan protocol. We run the model-artifact preparation once at
-    # startup; there is no per-process shutdown work to do.
+    # Starlette 1.0 removed `on_startup` / `on_shutdown` in favor of the ASGI lifespan protocol.
+    #
+    # There is no shutdown work to do: uvicorn stops accepting, waits for in-flight request
+    # handlers, and only then runs this hook — a request queued on the inference semaphore is
+    # inside its handler too, so it is waited on as well. What keeps a long inference from being
+    # cut off is gunicorn's --graceful-timeout, set in scripts/entrypoint.sh.
     await prepare_model_artifacts()
     yield
 
@@ -100,7 +142,9 @@ async def metrics(request):
 
 async def predict(request):
     # Shed load before reading the body: a worker whose latency has drifted far above its baseline
-    # is better off refusing quickly than queueing work its callers will time out on.
+    # is better off refusing quickly than queueing work its callers will time out on. Deliberately
+    # outside the idle witness below: a request we refuse is not activity, and must not keep an
+    # otherwise idle worker alive.
     if not latency_guard.accepting:
         return Response(
             Jsoner.serialize({"error": "Service temporarily unavailable, overload detected"}),
@@ -108,7 +152,19 @@ async def predict(request):
             media_type="application/json",
         )
 
+    # The idle checker must see this request: it counts what is in flight, so it cannot terminate
+    # the worker between the moment we start and the moment we answer.
+    async with idle.request_witnesses():
+        return await _predict(request)
+
+
+async def _predict(request):
     try:
+        # With idle unloading the model is not loaded at startup, so the first request pays for it.
+        # No-ops once loaded.
+        await ensure_model_downloaded()
+        inference_handler = await ensure_handler_loaded()
+
         # extracts content from request
         content_type = request.headers.get("content-Type", os.environ.get("DEFAULT_CONTENT_TYPE", ""))
         # try to deserialize payload
@@ -140,8 +196,8 @@ async def predict(request):
         # tracks request time
         start_time = perf_counter()
         # run async not blocking call, skipping it if the caller is gone by the time a slot frees
-        pred = await async_handler_call(
-            inference_handler, deserialized_body, request if should_discard_left() else None
+        pred = await async_call(
+            inference_handler, deserialized_body, request=request if should_discard_left() else None
         )
         # log request time
         logger.info(

--- a/tests/integ/conftest.py
+++ b/tests/integ/conftest.py
@@ -9,7 +9,7 @@ import pytest
 import tenacity
 from transformers.testing_utils import _run_slow_tests
 
-from huggingface_inference_toolkit.utils import _load_repository_from_hf
+from huggingface_inference_toolkit.heavy_utils import load_repository_from_hf
 from tests.integ.config import task2model
 
 HF_HUB_CACHE = os.environ.get("HF_HUB_CACHE", "/home/ubuntu/.cache/huggingface/hub")
@@ -124,7 +124,7 @@ def local_container(device, task, repository_id, framework):
         object_id = model.replace("/", "--")
         model_dir = f"{HF_HUB_CACHE}/{object_id}"
 
-        _storage_dir = _load_repository_from_hf(
+        _storage_dir = load_repository_from_hf(
             repository_id=model, target_dir=model_dir
         )
 

--- a/tests/integ/helpers.py
+++ b/tests/integ/helpers.py
@@ -10,7 +10,7 @@ import requests
 from docker import DockerClient
 from transformers.testing_utils import _run_slow_tests, require_tf, require_torch
 
-from huggingface_inference_toolkit.utils import _load_repository_from_hf
+from huggingface_inference_toolkit.heavy_utils import load_repository_from_hf
 from tests.integ.config import task2input, task2model, task2output, task2validation
 
 IS_GPU = _run_slow_tests
@@ -207,7 +207,7 @@ def test_pt_container_local_model(task: str) -> None:
     make_sure_other_containers_are_stopped(client, container_name)
     with tempfile.TemporaryDirectory() as tmpdirname:
         # https://github.com/huggingface/infinity/blob/test-ovh/test/integ/utils.py
-        _load_repository_from_hf(model, tmpdirname, framework="pytorch")
+        load_repository_from_hf(model, tmpdirname, framework="pytorch")
         container = client.containers.run(
             container_image,
             name=container_name,
@@ -238,7 +238,7 @@ def test_pt_container_custom_handler(repository_id) -> None:
     make_sure_other_containers_are_stopped(client, container_name)
     with tempfile.TemporaryDirectory() as tmpdirname:
         # https://github.com/huggingface/infinity/blob/test-ovh/test/integ/utils.py
-        _storage_dir = _load_repository_from_hf(repository_id, tmpdirname)
+        _storage_dir = load_repository_from_hf(repository_id, tmpdirname)
         container = client.containers.run(
             container_image,
             name=container_name,
@@ -275,7 +275,7 @@ def test_pt_container_legacy_custom_pipeline(repository_id: str) -> None:
     make_sure_other_containers_are_stopped(client, container_name)
     with tempfile.TemporaryDirectory() as tmpdirname:
         # https://github.com/huggingface/infinity/blob/test-ovh/test/integ/utils.py
-        _storage_dir = _load_repository_from_hf(repository_id, tmpdirname)
+        _storage_dir = load_repository_from_hf(repository_id, tmpdirname)
         container = client.containers.run(
             container_image,
             name=container_name,
@@ -393,7 +393,7 @@ def test_tf_container_local_model(task) -> None:
     make_sure_other_containers_are_stopped(client, container_name)
     with tempfile.TemporaryDirectory() as tmpdirname:
         # https://github.com/huggingface/infinity/blob/test-ovh/test/integ/utils.py
-        _storage_dir = _load_repository_from_hf(model, tmpdirname, framework=framework)
+        _storage_dir = load_repository_from_hf(model, tmpdirname, framework=framework)
         container = client.containers.run(
             container_image,
             name=container_name,
@@ -421,7 +421,7 @@ def test_tf_container_local_model(task) -> None:
 #     make_sure_other_containers_are_stopped(client, container_name)
 #     with tempfile.TemporaryDirectory() as tmpdirname:
 #         # https://github.com/huggingface/infinity/blob/test-ovh/test/integ/utils.py
-#         storage_dir = _load_repository_from_hf("philschmid/custom-pipeline-text-classification", tmpdirname)
+#         storage_dir = load_repository_from_hf("philschmid/custom-pipeline-text-classification", tmpdirname)
 #         container = client.containers.run(
 #             container_image,
 #             name=container_name,

--- a/tests/unit/test_api_inference_compat.py
+++ b/tests/unit/test_api_inference_compat.py
@@ -19,10 +19,7 @@ class FakePipeline:
 
 
 def handler_for(task, returns=None):
-    # bypass __init__, which would load a model
-    handler = HuggingFaceHandler.__new__(HuggingFaceHandler)
-    handler.pipeline = FakePipeline(task, returns)
-    return handler
+    return HuggingFaceHandler(FakePipeline(task, returns))
 
 
 @pytest.fixture

--- a/tests/unit/test_async_utils.py
+++ b/tests/unit/test_async_utils.py
@@ -1,10 +1,12 @@
+from functools import partial
+
 import anyio
 
-from huggingface_inference_toolkit.async_utils import async_handler_call
+from huggingface_inference_toolkit.async_utils import async_call
 
 
 class FakeRequest:
-    """Only what async_handler_call touches: the disconnect poll."""
+    """Only what async_call touches: the disconnect poll."""
 
     def __init__(self, *verdicts):
         self._verdicts = list(verdicts)
@@ -19,7 +21,9 @@ def test_runs_the_handler_when_the_caller_is_still_there():
     calls = []
     request = FakeRequest(False, False)
 
-    result = anyio.run(async_handler_call, lambda body: calls.append(body) or "prediction", {"inputs": "x"}, request)
+    result = anyio.run(
+        partial(async_call, lambda body: calls.append(body) or "prediction", {"inputs": "x"}, request=request)
+    )
 
     assert result == "prediction"
     assert calls == [{"inputs": "x"}]
@@ -29,7 +33,7 @@ def test_skips_the_handler_when_the_caller_has_left():
     calls = []
     request = FakeRequest(True)
 
-    result = anyio.run(async_handler_call, lambda body: calls.append(body), {"inputs": "x"}, request)
+    result = anyio.run(partial(async_call, lambda body: calls.append(body), {"inputs": "x"}, request=request))
 
     # None is what makes predict() answer 204
     assert result is None
@@ -40,7 +44,7 @@ def test_does_not_poll_when_the_feature_is_off():
     # predict() passes request=None when DISCARD_LEFT is not set, so nothing is checked
     calls = []
 
-    result = anyio.run(async_handler_call, lambda body: calls.append(body) or "prediction", {"inputs": "x"})
+    result = anyio.run(partial(async_call, lambda body: calls.append(body) or "prediction", {"inputs": "x"}))
 
     assert result == "prediction"
     assert calls == [{"inputs": "x"}]
@@ -53,7 +57,7 @@ def test_detects_a_departed_caller_that_only_shows_on_the_second_poll():
     calls = []
     request = FakeRequest(False, True)
 
-    result = anyio.run(async_handler_call, lambda body: calls.append(body), {"inputs": "x"}, request)
+    result = anyio.run(partial(async_call, lambda body: calls.append(body), {"inputs": "x"}, request=request))
 
     assert result is None
     assert calls == []

--- a/tests/unit/test_diffusers.py
+++ b/tests/unit/test_diffusers.py
@@ -5,14 +5,14 @@ from PIL import Image
 from transformers.testing_utils import require_torch, slow
 
 from huggingface_inference_toolkit.diffusers_utils import IEAutoPipelineForText2Image
-from huggingface_inference_toolkit.utils import _load_repository_from_hf, get_pipeline
+from huggingface_inference_toolkit.heavy_utils import get_pipeline, load_repository_from_hf
 
 logging.basicConfig(level="DEBUG")
 
 @require_torch
 def test_get_diffusers_pipeline():
     with tempfile.TemporaryDirectory() as tmpdirname:
-        storage_dir = _load_repository_from_hf(
+        storage_dir = load_repository_from_hf(
             "echarlaix/tiny-random-stable-diffusion-xl",
             tmpdirname,
             framework="pytorch"
@@ -25,7 +25,7 @@ def test_get_diffusers_pipeline():
 @require_torch
 def test_pipe_on_gpu():
     with tempfile.TemporaryDirectory() as tmpdirname:
-        storage_dir = _load_repository_from_hf(
+        storage_dir = load_repository_from_hf(
             "echarlaix/tiny-random-stable-diffusion-xl",
             tmpdirname,
             framework="pytorch"
@@ -41,7 +41,7 @@ def test_pipe_on_gpu():
 @require_torch
 def test_text_to_image_task():
     with tempfile.TemporaryDirectory() as tmpdirname:
-        storage_dir = _load_repository_from_hf(
+        storage_dir = load_repository_from_hf(
             "echarlaix/tiny-random-stable-diffusion-xl",
             tmpdirname,
             framework="pytorch"

--- a/tests/unit/test_env_knobs.py
+++ b/tests/unit/test_env_knobs.py
@@ -1,5 +1,7 @@
+from functools import partial
 from types import SimpleNamespace
 
+import anyio
 import pytest
 
 from huggingface_inference_toolkit import diffusers_utils
@@ -31,7 +33,12 @@ def repo_with_a_custom_handler(monkeypatch):
         return "custom handler"
 
     monkeypatch.setattr(handler_module, "check_and_register_custom_pipeline_from_directory", register)
-    monkeypatch.setattr(handler_module, "HuggingFaceHandler", lambda model_dir, task: "default handler")
+    class FakeDefaultHandler:
+        @staticmethod
+        async def create(model_dir, task):
+            return "default handler"
+
+    monkeypatch.setattr(handler_module, "HuggingFaceHandler", FakeDefaultHandler)
     monkeypatch.delenv("AIP_MODE", raising=False)
     return looked
 
@@ -39,18 +46,16 @@ def repo_with_a_custom_handler(monkeypatch):
 def test_custom_handler_is_used_by_default(monkeypatch, repo_with_a_custom_handler):
     monkeypatch.delenv("IGNORE_CUSTOM_HANDLER", raising=False)
 
-    assert get_inference_handler_either_custom_or_default_handler("/model", task="text-classification") == (
-        "custom handler"
-    )
+    resolve = partial(get_inference_handler_either_custom_or_default_handler, "/model", task="text-classification")
+    assert anyio.run(resolve) == "custom handler"
     assert repo_with_a_custom_handler == ["/model"]
 
 
 def test_custom_handler_is_skipped_when_ignored(monkeypatch, repo_with_a_custom_handler):
     monkeypatch.setenv("IGNORE_CUSTOM_HANDLER", "1")
 
-    assert get_inference_handler_either_custom_or_default_handler("/model", task="text-classification") == (
-        "default handler"
-    )
+    resolve = partial(get_inference_handler_either_custom_or_default_handler, "/model", task="text-classification")
+    assert anyio.run(resolve) == "default handler"
     # not even looked for: importing a repo's handler.py executes its module-level code
     assert repo_with_a_custom_handler == []
 

--- a/tests/unit/test_handler.py
+++ b/tests/unit/test_handler.py
@@ -1,3 +1,4 @@
+import asyncio
 import tempfile
 from typing import Dict
 
@@ -9,9 +10,9 @@ from huggingface_inference_toolkit.handler import (
     HuggingFaceHandler,
     get_inference_handler_either_custom_or_default_handler,
 )
-from huggingface_inference_toolkit.utils import (
+from huggingface_inference_toolkit.heavy_utils import (
     _is_gpu_available,
-    _load_repository_from_hf,
+    load_repository_from_hf,
 )
 
 TASK = "text-classification"
@@ -30,8 +31,8 @@ def test_pt_get_device() -> None:
 
     with tempfile.TemporaryDirectory() as tmpdirname:
         # https://github.com/huggingface/infinity/blob/test-ovh/test/integ/utils.py
-        storage_dir = _load_repository_from_hf(MODEL, tmpdirname, framework="pytorch")
-        h = HuggingFaceHandler(model_dir=str(storage_dir), task=TASK)
+        storage_dir = load_repository_from_hf(MODEL, tmpdirname, framework="pytorch")
+        h = asyncio.run(HuggingFaceHandler.create(str(storage_dir), task=TASK))
         if torch.cuda.is_available():
             assert h.pipeline.model.device == torch.device(type="cuda", index=0)
         else:
@@ -42,8 +43,8 @@ def test_pt_get_device() -> None:
 def test_pt_predict_call(input_data: Dict[str, str]) -> None:
     with tempfile.TemporaryDirectory() as tmpdirname:
         # https://github.com/huggingface/infinity/blob/test-ovh/test/integ/utils.py
-        storage_dir = _load_repository_from_hf(MODEL, tmpdirname, framework="pytorch")
-        h = HuggingFaceHandler(model_dir=str(storage_dir), task=TASK)
+        storage_dir = load_repository_from_hf(MODEL, tmpdirname, framework="pytorch")
+        h = asyncio.run(HuggingFaceHandler.create(str(storage_dir), task=TASK))
 
         prediction = h(input_data)
         assert "label" in prediction[0]
@@ -53,22 +54,22 @@ def test_pt_predict_call(input_data: Dict[str, str]) -> None:
 @require_torch
 def test_pt_custom_pipeline(input_data: Dict[str, str]) -> None:
     with tempfile.TemporaryDirectory() as tmpdirname:
-        storage_dir = _load_repository_from_hf(
+        storage_dir = load_repository_from_hf(
             "philschmid/custom-pipeline-text-classification",
             tmpdirname,
             framework="pytorch",
         )
-        h = get_inference_handler_either_custom_or_default_handler(str(storage_dir), task="custom")
+        h = asyncio.run(get_inference_handler_either_custom_or_default_handler(str(storage_dir), task="custom"))
         assert h(input_data) == input_data
 
 
 @require_torch
 def test_pt_sentence_transformers_pipeline(input_data: Dict[str, str]) -> None:
     with tempfile.TemporaryDirectory() as tmpdirname:
-        storage_dir = _load_repository_from_hf(
+        storage_dir = load_repository_from_hf(
             "sentence-transformers/all-MiniLM-L6-v2", tmpdirname, framework="pytorch"
         )
-        h = get_inference_handler_either_custom_or_default_handler(str(storage_dir), task="sentence-embeddings")
+        h = asyncio.run(get_inference_handler_either_custom_or_default_handler(str(storage_dir), task="sentence-embeddings"))
         pred = h(input_data)
         assert isinstance(pred["embeddings"], np.ndarray)
 
@@ -77,8 +78,8 @@ def test_pt_sentence_transformers_pipeline(input_data: Dict[str, str]) -> None:
 def test_tf_get_device():
     with tempfile.TemporaryDirectory() as tmpdirname:
         # https://github.com/huggingface/infinity/blob/test-ovh/test/integ/utils.py
-        storage_dir = _load_repository_from_hf(MODEL, tmpdirname, framework="tensorflow")
-        h = HuggingFaceHandler(model_dir=str(storage_dir), task=TASK)
+        storage_dir = load_repository_from_hf(MODEL, tmpdirname, framework="tensorflow")
+        h = asyncio.run(HuggingFaceHandler.create(str(storage_dir), task=TASK))
         if _is_gpu_available():
             assert h.pipeline.device == 0
         else:
@@ -89,8 +90,8 @@ def test_tf_get_device():
 def test_tf_predict_call(input_data: Dict[str, str]) -> None:
     with tempfile.TemporaryDirectory() as tmpdirname:
         # https://github.com/huggingface/infinity/blob/test-ovh/test/integ/utils.py
-        storage_dir = _load_repository_from_hf(MODEL, tmpdirname, framework="tensorflow")
-        handler = HuggingFaceHandler(model_dir=str(storage_dir), task=TASK, framework="tf")
+        storage_dir = load_repository_from_hf(MODEL, tmpdirname, framework="tensorflow")
+        handler = asyncio.run(HuggingFaceHandler.create(str(storage_dir), task=TASK, framework="tf"))
 
         prediction = handler(input_data)
         assert "label" in prediction[0]
@@ -100,12 +101,12 @@ def test_tf_predict_call(input_data: Dict[str, str]) -> None:
 @require_tf
 def test_tf_custom_pipeline(input_data: Dict[str, str]) -> None:
     with tempfile.TemporaryDirectory() as tmpdirname:
-        storage_dir = _load_repository_from_hf(
+        storage_dir = load_repository_from_hf(
             "philschmid/custom-pipeline-text-classification",
             tmpdirname,
             framework="tensorflow",
         )
-        h = get_inference_handler_either_custom_or_default_handler(str(storage_dir), task="custom")
+        h = asyncio.run(get_inference_handler_either_custom_or_default_handler(str(storage_dir), task="custom"))
         assert h(input_data) == input_data
 
 
@@ -113,8 +114,8 @@ def test_tf_custom_pipeline(input_data: Dict[str, str]) -> None:
 def test_tf_sentence_transformers_pipeline():
     # TODO should fail! because TF is not supported yet
     with tempfile.TemporaryDirectory() as tmpdirname:
-        storage_dir = _load_repository_from_hf(
+        storage_dir = load_repository_from_hf(
             "sentence-transformers/all-MiniLM-L6-v2", tmpdirname, framework="tensorflow"
         )
         with pytest.raises(Exception) as _exc_info:
-            get_inference_handler_either_custom_or_default_handler(str(storage_dir), task="sentence-embeddings")
+            asyncio.run(get_inference_handler_either_custom_or_default_handler(str(storage_dir), task="sentence-embeddings"))

--- a/tests/unit/test_optimum_utils.py
+++ b/tests/unit/test_optimum_utils.py
@@ -4,12 +4,12 @@ import tempfile
 import pytest
 from transformers.testing_utils import require_torch
 
+from huggingface_inference_toolkit.heavy_utils import load_repository_from_hf
 from huggingface_inference_toolkit.optimum_utils import (
     get_input_shapes,
     get_optimum_neuron_pipeline,
     is_optimum_neuron_available,
 )
-from huggingface_inference_toolkit.utils import _load_repository_from_hf
 
 require_inferentia = pytest.mark.skipif(
     not is_optimum_neuron_available(),
@@ -34,7 +34,7 @@ def test_not_supported_task():
 @require_inferentia
 def test_get_input_shapes_from_file():
     with tempfile.TemporaryDirectory() as tmpdirname:
-        storage_folder = _load_repository_from_hf(
+        storage_folder = load_repository_from_hf(
             repository_id=REMOTE_CONVERTED_MODEL,
             target_dir=tmpdirname,
         )
@@ -49,7 +49,7 @@ def test_get_input_shapes_from_env():
     os.environ["HF_OPTIMUM_BATCH_SIZE"] = "4"
     os.environ["HF_OPTIMUM_SEQUENCE_LENGTH"] = "32"
     with tempfile.TemporaryDirectory() as tmpdirname:
-        storage_folder = _load_repository_from_hf(
+        storage_folder = load_repository_from_hf(
             repository_id=REMOTE_NOT_CONVERTED_MODEL,
             target_dir=tmpdirname,
         )
@@ -77,7 +77,7 @@ def test_get_optimum_neuron_pipeline_from_converted_model():
 def test_get_optimum_neuron_pipeline_from_non_converted_model():
     os.environ["HF_OPTIMUM_SEQUENCE_LENGTH"] = "32"
     with tempfile.TemporaryDirectory() as tmpdirname:
-        storage_folder = _load_repository_from_hf(
+        storage_folder = load_repository_from_hf(
             repository_id=REMOTE_NOT_CONVERTED_MODEL,
             target_dir=tmpdirname,
         )

--- a/tests/unit/test_sentence_transformers.py
+++ b/tests/unit/test_sentence_transformers.py
@@ -4,20 +4,20 @@ import numpy as np
 import pytest
 from transformers.testing_utils import require_torch
 
+from huggingface_inference_toolkit.heavy_utils import (
+    get_pipeline,
+    load_repository_from_hf,
+)
 from huggingface_inference_toolkit.sentence_transformers_utils import (
     SentenceEmbeddingPipeline,
     get_sentence_transformers_pipeline,
-)
-from huggingface_inference_toolkit.utils import (
-    _load_repository_from_hf,
-    get_pipeline,
 )
 
 
 @require_torch
 def test_get_sentence_transformers_pipeline():
     with tempfile.TemporaryDirectory() as tmpdirname:
-        storage_dir = _load_repository_from_hf("sentence-transformers/all-MiniLM-L6-v2", tmpdirname)
+        storage_dir = load_repository_from_hf("sentence-transformers/all-MiniLM-L6-v2", tmpdirname)
         pipe = get_pipeline("sentence-embeddings", storage_dir.as_posix())
         assert isinstance(pipe, SentenceEmbeddingPipeline)
 
@@ -25,7 +25,7 @@ def test_get_sentence_transformers_pipeline():
 @require_torch
 def test_sentence_embedding_task():
     with tempfile.TemporaryDirectory() as tmpdirname:
-        storage_dir = _load_repository_from_hf("sentence-transformers/all-MiniLM-L6-v2", tmpdirname)
+        storage_dir = load_repository_from_hf("sentence-transformers/all-MiniLM-L6-v2", tmpdirname)
         pipe = get_sentence_transformers_pipeline("sentence-embeddings", storage_dir.as_posix())
         res = pipe(sentences="Lets create an embedding")
         assert isinstance(res["embeddings"], np.ndarray)
@@ -37,7 +37,7 @@ def test_sentence_embedding_task():
 @require_torch
 def test_sentence_similarity():
     with tempfile.TemporaryDirectory() as tmpdirname:
-        storage_dir = _load_repository_from_hf("sentence-transformers/all-MiniLM-L6-v2", tmpdirname)
+        storage_dir = load_repository_from_hf("sentence-transformers/all-MiniLM-L6-v2", tmpdirname)
         pipe = get_sentence_transformers_pipeline("sentence-similarity", storage_dir.as_posix())
         res = pipe(source_sentence="Lets create an embedding", sentences=["Lets create an embedding"])
         assert isinstance(res["similarities"], list)
@@ -46,7 +46,7 @@ def test_sentence_similarity():
 @require_torch
 def test_sentence_ranking():
     with tempfile.TemporaryDirectory() as tmpdirname:
-        storage_dir = _load_repository_from_hf("cross-encoder/ms-marco-MiniLM-L-6-v2", tmpdirname)
+        storage_dir = load_repository_from_hf("cross-encoder/ms-marco-MiniLM-L-6-v2", tmpdirname)
         pipe = get_sentence_transformers_pipeline("sentence-ranking", storage_dir.as_posix())
         res = pipe(
             sentences=[
@@ -62,7 +62,7 @@ def test_sentence_ranking():
 @require_torch
 def test_sentence_ranking_tei():
     with tempfile.TemporaryDirectory() as tmpdirname:
-        storage_dir = _load_repository_from_hf("cross-encoder/ms-marco-MiniLM-L-6-v2", tmpdirname, framework="pytorch")
+        storage_dir = load_repository_from_hf("cross-encoder/ms-marco-MiniLM-L-6-v2", tmpdirname, framework="pytorch")
         pipe = get_sentence_transformers_pipeline("sentence-ranking", storage_dir.as_posix())
         res = pipe(
             query="Lets create an embedding",
@@ -83,7 +83,7 @@ def test_sentence_ranking_tei():
 @require_torch
 def test_sentence_ranking_validation_errors():
     with tempfile.TemporaryDirectory() as tmpdirname:
-        storage_dir = _load_repository_from_hf("cross-encoder/ms-marco-MiniLM-L-6-v2", tmpdirname, framework="pytorch")
+        storage_dir = load_repository_from_hf("cross-encoder/ms-marco-MiniLM-L-6-v2", tmpdirname, framework="pytorch")
         pipe = get_sentence_transformers_pipeline("sentence-ranking", storage_dir.as_posix())
 
         with pytest.raises(

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -1,3 +1,4 @@
+import asyncio
 import logging
 import os
 import tempfile
@@ -7,15 +8,17 @@ import pytest
 from transformers.file_utils import is_torch_available
 from transformers.testing_utils import require_tf, require_torch, slow
 
-from huggingface_inference_toolkit import utils as hf_utils
+from huggingface_inference_toolkit import heavy_utils as hf_heavy_utils
 from huggingface_inference_toolkit.handler import get_inference_handler_either_custom_or_default_handler
-from huggingface_inference_toolkit.utils import (
+from huggingface_inference_toolkit.heavy_utils import (
     _get_framework,
     _is_gpu_available,
-    _load_repository_from_hf,
+    get_pipeline,
+    load_repository_from_hf,
+)
+from huggingface_inference_toolkit.utils import (
     check_and_register_custom_pipeline_from_directory,
     convert_params_to_int_or_bool,
-    get_pipeline,
     should_discard_left,
 )
 
@@ -26,7 +29,7 @@ def test_load_revision_repository_from_hf():
     MODEL = "lysandre/tiny-bert-random"
     REVISION = "eb4c77816edd604d0318f8e748a1c606a2888493"
     with tempfile.TemporaryDirectory() as tmpdirname:
-        storage_folder = _load_repository_from_hf(MODEL, tmpdirname, revision=REVISION)
+        storage_folder = load_repository_from_hf(MODEL, tmpdirname, revision=REVISION)
         # folder contains all config files and pytorch_model.bin
         folder_contents = os.listdir(storage_folder)
         # revision doesn't have tokenizer
@@ -40,7 +43,7 @@ def test_load_tensorflow_repository_from_hf():
         tf_tmp = Path(tmpdirname).joinpath("tf")
         tf_tmp.mkdir(parents=True, exist_ok=True)
 
-        storage_folder = _load_repository_from_hf(MODEL, tf_tmp, framework="tensorflow")
+        storage_folder = load_repository_from_hf(MODEL, tf_tmp, framework="tensorflow")
         # folder contains all config files and pytorch_model.bin
         folder_contents = os.listdir(storage_folder)
         assert "pytorch_model.bin" not in folder_contents
@@ -56,7 +59,7 @@ def test_load_onnx_repository_from_hf():
         ox_tmp = Path(tmpdirname).joinpath("onnx")
         ox_tmp.mkdir(parents=True, exist_ok=True)
 
-        storage_folder = _load_repository_from_hf(MODEL, ox_tmp, framework="onnx")
+        storage_folder = load_repository_from_hf(MODEL, ox_tmp, framework="onnx")
         # folder contains all config files and pytorch_model.bin
         folder_contents = os.listdir(storage_folder)
         assert "pytorch_model.bin" not in folder_contents
@@ -77,7 +80,7 @@ def test_load_pytorch_repository_from_hf():
         pt_tmp = Path(tmpdirname).joinpath("pt")
         pt_tmp.mkdir(parents=True, exist_ok=True)
 
-        storage_folder = _load_repository_from_hf(MODEL, pt_tmp, framework="pytorch")
+        storage_folder = load_repository_from_hf(MODEL, pt_tmp, framework="pytorch")
         # folder contains all config files and pytorch_model.bin
         folder_contents = os.listdir(storage_folder)
         assert "pytorch_model.bin" in folder_contents
@@ -113,7 +116,7 @@ def test_get_pipeline():
     MODEL = "hf-internal-testing/tiny-random-BertForSequenceClassification"
     TASK = "text-classification"
     with tempfile.TemporaryDirectory() as tmpdirname:
-        storage_dir = _load_repository_from_hf(MODEL, tmpdirname, framework="pytorch")
+        storage_dir = load_repository_from_hf(MODEL, tmpdirname, framework="pytorch")
         pipe = get_pipeline(
             task = TASK,
             model_dir = storage_dir.as_posix(),
@@ -125,7 +128,7 @@ def test_get_pipeline():
 @require_torch
 def test_whisper_long_audio(cache_test_dir):
     with tempfile.TemporaryDirectory() as tmpdirname:
-        storage_dir = _load_repository_from_hf(
+        storage_dir = load_repository_from_hf(
             repository_id = "openai/whisper-tiny",
             target_dir = tmpdirname,
         )
@@ -143,7 +146,7 @@ def test_whisper_long_audio(cache_test_dir):
 @require_torch
 def test_wrapped_pipeline():
     with tempfile.TemporaryDirectory() as tmpdirname:
-        storage_dir = _load_repository_from_hf(
+        storage_dir = load_repository_from_hf(
             repository_id = "microsoft/DialoGPT-small",
             target_dir = tmpdirname,
             framework="pytorch"
@@ -179,7 +182,7 @@ def test_local_custom_pipeline(cache_test_dir):
 
 def test_remote_custom_pipeline():
     with tempfile.TemporaryDirectory() as tmpdirname:
-        storage_dir = _load_repository_from_hf(
+        storage_dir = load_repository_from_hf(
             "philschmid/custom-pipeline-text-classification",
             tmpdirname,
             framework="pytorch"
@@ -192,12 +195,12 @@ def test_remote_custom_pipeline():
 
 def test_get_inference_handler_either_custom_or_default_pipeline():
     with tempfile.TemporaryDirectory() as tmpdirname:
-        storage_dir = _load_repository_from_hf(
+        storage_dir = load_repository_from_hf(
             "philschmid/custom-pipeline-text-classification",
             tmpdirname,
             framework="pytorch"
         )
-        pipeline = get_inference_handler_either_custom_or_default_handler(str(storage_dir))
+        pipeline = asyncio.run(get_inference_handler_either_custom_or_default_handler(str(storage_dir)))
         payload = "test"
         assert pipeline.path == str(storage_dir)
         assert pipeline(payload) == payload
@@ -205,7 +208,7 @@ def test_get_inference_handler_either_custom_or_default_pipeline():
     with tempfile.TemporaryDirectory() as tmpdirname:
         MODEL = "lysandre/tiny-bert-random"
         TASK = "text-classification"
-        pipeline = get_inference_handler_either_custom_or_default_handler(MODEL, TASK)
+        pipeline = asyncio.run(get_inference_handler_either_custom_or_default_handler(MODEL, TASK))
         res = pipeline({"inputs": "Life is good, Life is bad"})
         assert "score" in res[0]
 
@@ -245,10 +248,10 @@ def test_safetensors_probe_asks_about_the_revision_being_downloaded(monkeypatch,
         seen["download_revision"] = kwargs.get("revision")
         seen["ignore_patterns"] = kwargs.get("ignore_patterns")
 
-    monkeypatch.setattr(hf_utils.HfApi, "model_info", fake_model_info)
-    monkeypatch.setattr(hf_utils, "snapshot_download", fake_snapshot_download)
+    monkeypatch.setattr(hf_heavy_utils.HfApi, "model_info", fake_model_info)
+    monkeypatch.setattr(hf_heavy_utils, "snapshot_download", fake_snapshot_download)
 
-    hf_utils._load_repository_from_hf("some/model", tmp_path, framework="pytorch", revision=revision)
+    hf_heavy_utils.load_repository_from_hf("some/model", tmp_path, framework="pytorch", revision=revision)
 
     assert seen["probe_revision"] == revision
     assert seen["probe_revision"] == seen["download_revision"]
@@ -263,12 +266,12 @@ def test_safetensors_probe_keeps_bin_weights_when_the_revision_has_no_safetensor
     class _Info:
         siblings = [_Sibling("config.json"), _Sibling("pytorch_model.bin")]
 
-    monkeypatch.setattr(hf_utils.HfApi, "model_info", lambda self, repo_id, **kw: _Info())
+    monkeypatch.setattr(hf_heavy_utils.HfApi, "model_info", lambda self, repo_id, **kw: _Info())
     monkeypatch.setattr(
-        hf_utils, "snapshot_download", lambda **kw: seen.update(ignore_patterns=kw.get("ignore_patterns"))
+        hf_heavy_utils, "snapshot_download", lambda **kw: seen.update(ignore_patterns=kw.get("ignore_patterns"))
     )
 
-    hf_utils._load_repository_from_hf("some/model", tmp_path, framework="pytorch", revision="abc123")
+    hf_heavy_utils.load_repository_from_hf("some/model", tmp_path, framework="pytorch", revision="abc123")
 
     # no safetensors at this revision, so the .bin weights are the ones that must survive
     assert "pytorch*" not in seen["ignore_patterns"]


### PR DESCRIPTION
porting tha api-inference-mini-fork UNLOAD_IDLE feature on main, as one PR

**Off unless `UNLOAD_IDLE=1`.** With the flag unset the only behavioural change is that startup loads the model through a thread rather than on the event loop.

The point: let a node host more workers than it has models resident. A worker starts cheap, loads on first use, and terminates itself once it goes quiet so the memory actually comes back.

## The four parts

**`heavy_utils`** — the transformers / diffusers / sentence-transformers imports move out of `utils` into their own module, imported at the point of use. An idle worker whose model is gone shouldn't still be carrying those libraries, and `utils` is imported by everything.

**Asynchronous loading** — `HuggingFaceHandler.__init__` took a model directory and loaded a model; it now takes an already-built pipeline, with `await HuggingFaceHandler.create(...)` doing the load through `async_call`. Resolving a handler is async for the same reason. This is what makes lazy loading *safe*: seconds of blocking work inside a request would otherwise stall every other connection on the worker. `get_pipeline` takes its extra arguments as a dict because `anyio.to_thread.run_sync` forwards positional arguments only.

**Idle unloading** — `idle.live_check_loop` watches for inactivity and SIGTERMs its own worker; gunicorn replaces it, and the next request pays for a fresh load. In-flight requests are counted with a semaphore rather than inferred from timestamps, so a worker can't decide it's idle while it's busy.

**Graceful shutdown** — the entrypoint runs gunicorn with `WORKERS` and `--graceful-timeout ${GRACEFUL_TIMEOUT:-300}`. gunicorn's own default is 30 s, which silently truncates any inference longer than that when a pod is asked to stop.

## Verified against the real service

Through `scripts/entrypoint.sh`, gunicorn + UvicornWorker, not just unit tests.

**Lazy load** — startup logs no model load; the first request loads and answers:

```
[2126077] Booting worker with pid: 2126077
INFO - Idle unloading enabled, deferring model load to the first request
INFO - Starting live check loop
                       <- "Model initialized successfully" count: 0
POST / -> [{"label":"LABEL_0",...}]
                       <- count: 1
```

**Idle unload and respawn**:

```
16:13:58 Idle checker: worker inactive for too long. Leaving live check loop
16:13:58 Aborting this idle worker
16:13:58 [2126402] Booting worker with pid: 2126402    <- served the next request, count: 2
```

**No self-kill mid-request** — a 15.8 s request against `IDLE_TIMEOUT=10` returned 200, with the checker declining on every tick:

```
idle checker: 1 requests likely being processed for pid 2126582, it won't be killed   (x4)
```

**Graceful shutdown**, SIGTERM to the master 4 s into a ~15 s inference:

| `GRACEFUL_TIMEOUT` | result |
|---|---|
| `300` (new default) | `http=200`, completed at 14.7 s |
| `5` | `http=000`, killed at 9 s |

## `drain_queue` is deliberately not ported

The fork pairs the graceful timeout with a `drain_queue()` hook on lifespan shutdown (`e6c814e`). It cannot do anything, so it's left out.

uvicorn stops accepting, waits for in-flight request handlers, and *only then* runs the lifespan shutdown — and a request queued on the inference semaphore is inside its handler too, so it's waited on as well. The logs show the ordering directly:

```
16:25:52  Handling signal: term            <- SIGTERM, 4s into a 15s inference
16:26:02  POST / | Duration: 14746.40 ms   <- request finishes
16:26:02  Shutdown: queue drained          <- the hook only runs now
```

By the time it runs the queue is empty by construction. Across 8 shutdowns it found pending work **0** times. It was also an unbounded `while` loop in the shutdown path: if its invariant were ever violated it could only spend the whole graceful window and then be SIGKILLed.

Removing it changes nothing measurable — with the hook gone, SIGTERM mid-inference still completes (`http=200`, 13.3 s). The reasoning is left as a comment on the lifespan so it doesn't get reintroduced.

Related trap, in case it comes up again: SIGTERM sent to a *worker* is handled by uvicorn, which waits for in-flight requests with no deadline. `--graceful-timeout` is the arbiter's patience once the *master* is signalled. My first A/B tested the wrong signal and made the flag look like it did nothing.

## Ported as the end state, not as history

`f382945`, `ad1e647` and `4c6eb8c` in the fork repair bugs the fork's *own* lazy loading introduced — a sync context manager on the async path, a worker able to SIGTERM itself mid-request, a synchronous load moved inside a request. None is a latent bug on `main`, which only loads at startup. Porting `46fa298`'s fixed state means they never exist here.

One deliberate difference: `get_pipeline`'s kwargs dict is optional rather than required (the fork passes `{}` at every call site), and it's copied rather than mutated in place.

## Tests

The suite migrates to the new constructor — `asyncio.run(HuggingFaceHandler.create(...))` — and to `heavy_utils` for the moved helpers. `ruff check src tests` clean; `tests/unit` is 109 passed / 13 skipped, with the same 10 failures as `main` in this environment (missing `sentence_transformers`, `diffusers`, `google-cloud-storage`), verified as an identical set by diffing against a stashed baseline.

Next: `/pipeline/{task}` + the per-task handler cache, which needed this PR's async load to exist.
