### PR TITLE
fix(ci): the runner context is not available in a job-level env block

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,6 @@
 .git
 .github
+.hf_cache
 .pytest_cache
 .ruff_cache
 .tox

--- a/.github/workflows/build-container.yaml
+++ b/.github/workflows/build-container.yaml
@@ -20,7 +20,14 @@ jobs:
     with:
       image: inference-pytorch-cpu
       dockerfile: dockerfiles/pytorch/Dockerfile
-      build_args: "BASE_IMAGE=ubuntu:22.04"
+      target: runtime
+      # Same three args the Makefile's CPU target passes. BASE_IMAGE alone is not enough since the
+      # build was split: RUNTIME_IMAGE would keep the CUDA runtime base and TORCH_REQUIREMENTS would
+      # keep the CUDA wheels, so the "cpu" image would ship CUDA.
+      build_args: |
+        BASE_IMAGE=ubuntu:22.04
+        RUNTIME_IMAGE=ubuntu:22.04
+        TORCH_REQUIREMENTS=requirements-torch-cpu.txt
     secrets:
       REGISTRY_USERNAME: ${{ secrets.REGISTRY_USERNAME }}
       REGISTRY_PASSWORD: ${{ secrets.REGISTRY_PASSWORD }}
@@ -29,6 +36,7 @@ jobs:
     with:
       image: inference-pytorch-gpu
       dockerfile: dockerfiles/pytorch/Dockerfile
+      target: runtime
     secrets:
       REGISTRY_USERNAME: ${{ secrets.REGISTRY_USERNAME }}
       REGISTRY_PASSWORD: ${{ secrets.REGISTRY_PASSWORD }}

--- a/.github/workflows/docker-build-action.yaml
+++ b/.github/workflows/docker-build-action.yaml
@@ -20,6 +20,12 @@ on:
         type: string
         required: false
         default: "Dockerfile"
+      # Which Dockerfile stage to publish. Defaults to the single-stage name Dockerfile.inf2 still
+      # uses; the multi-stage pytorch Dockerfile has to ask for "runtime" explicitly.
+      target:
+        type: string
+        required: false
+        default: "base"
     secrets:
       REGISTRY_USERNAME:
         required: true
@@ -55,7 +61,7 @@ jobs:
           push: true
           context: ${{ inputs.context }}
           build-args: ${{ inputs.build_args }}
-          target: base
+          target: ${{ inputs.target }}
           outputs: type=image,compression=zstd,force-compression=true,push=true
           file: ${{ inputs.context }}/${{ inputs.dockerfile }}
           tags: ${{ inputs.repository }}/${{ inputs.image }}:sha-${{ env.GITHUB_SHA_SHORT }},${{ inputs.repository }}/${{ inputs.image }}:latest

--- a/.github/workflows/integration-test-action.yaml
+++ b/.github/workflows/integration-test-action.yaml
@@ -39,15 +39,18 @@ jobs:
       group: ${{ inputs.runs_on }}
     env:
       AWS_REGION: ${{ inputs.region }}
-      # Keep the model cache in the job's own scratch dir, so a run never depends on cache state
-      # it does not own. runner.temp is emptied by the runner at the start and end of every job,
-      # unlike $HOME, which on these long-lived self-hosted runners survives across jobs and would
-      # reintroduce exactly the shared state we are removing here.
+      # Keep the model cache in the job's own workspace, so a run never depends on cache state it
+      # does not own: actions/checkout runs `git clean -ffdx` below, so every job starts from an
+      # empty cache instead of inheriting whatever the previous job on this long-lived self-hosted
+      # runner left under $HOME.
+      # It has to be the workspace rather than runner.temp, tempting as that is: the `runner`
+      # context is not available in a job-level `env:` block, only inside steps, so ${{ runner.temp }}
+      # here makes the whole workflow file invalid.
       # It also has to stay a real path on the runner host: conftest hands the downloaded model dir
       # straight to `docker run -v`, so the docker daemon has to resolve it, not just pytest.
       # Models are re-downloaded every run; the integ fixtures are tiny on purpose.
-      HF_HOME: ${{ runner.temp }}/hf_cache
-      HF_HUB_CACHE: ${{ runner.temp }}/hf_cache/hub
+      HF_HOME: ${{ github.workspace }}/.hf_cache
+      HF_HUB_CACHE: ${{ github.workspace }}/.hf_cache/hub
       RUN_SLOW: ${{ inputs.run_slow }}
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2


### PR DESCRIPTION
The `runner` context is only available inside steps — not in `jobs.<job_id>.env`, where the allowed contexts are `github`, `needs`, `strategy`, `matrix`, `vars`, `inputs` and `secrets`.

#126 moved the integ-test model cache to `${{ runner.temp }}` in exactly that block, which made `integration-test-action.yaml` fail validation. Since `integration-test.yaml` does nothing but call it four times, **every** run of *Run Integration Tests* since has died at startup — zero jobs, no logs, and the run titled by its file path instead of its `name:`. That affects `main` and every branch, which is why the failures look identical regardless of what the commit under test changed.

- last green: `345e634` (2026-07-28 16:27) — 4/4 jobs, run named `Run Integration Tests`
- first red: `977e5b3` — same PR branch, `runner.temp` introduced
- 36 consecutive startup failures since, up to `2ddc1d9` on `main`

## What this does

Puts `HF_HOME` / `HF_HUB_CACHE` back under `${{ github.workspace }}`, which *is* available at job level and was the version that passed CI.

This keeps what #126 was after. The goal was that a job never inherits cache state from a previous job on these long-lived self-hosted runners, and `actions/checkout` runs `git clean -ffdx`, so the workspace cache is wiped at the start of every job. The one behavioural difference versus `runner.temp` is that cleanup is deferred to the next job on that workspace rather than happening at job end, so one run's fixtures sit on the runner disk in between. Bounded to a single workspace and a single run, and the integ fixtures are deliberately tiny.

Also adds `.hf_cache` to `.dockerignore`. Both build targets run `docker build … .` from the workspace root, and the cache now lives inside that context. Current step ordering (checkout → docker build → pytest) means it does not exist yet at build time, so this is not a live bug — but nothing was stopping a future reordering, or a `clean: false`, from shipping the downloaded weights to the daemon on every build.

## Verification

All six workflow files parse, and no job-level `env:` block in the repo references the `runner` context any more (the two remaining textual matches are inside a comment, which the YAML parser strips). The real confirmation is this PR's own *Run Integration Tests* check actually scheduling its four jobs — on `main` today it schedules none.