### PR TITLE
fix: stop importing sentence-transformers before the worker serves anything

### DIFF
--- a/src/huggingface_inference_toolkit/handler.py
+++ b/src/huggingface_inference_toolkit/handler.py
@@ -8,7 +8,6 @@ from huggingface_inference_toolkit.const import HF_TRUST_REMOTE_CODE
 from huggingface_inference_toolkit.env_utils import api_inference_compat, ignore_custom_handler
 from huggingface_inference_toolkit.latency_guard import latency_guard
 from huggingface_inference_toolkit.logging import logger
-from huggingface_inference_toolkit.sentence_transformers_utils import SENTENCE_TRANSFORMERS_TASKS
 from huggingface_inference_toolkit.utils import check_and_register_custom_pipeline_from_directory
 
 
@@ -65,6 +64,12 @@ class HuggingFaceHandler:
         return pred
 
     def _timed_call(self, data: Dict[str, Any]) -> Dict[str, Any]:
+        # Imported here, not at module level: sentence_transformers_utils imports
+        # sentence-transformers eagerly when it is installed, and this module is reachable from
+        # webservice_starlette, so importing it up there makes every worker carry the library —
+        # and, through it, torch and transformers — before it has been asked to serve anything.
+        from huggingface_inference_toolkit.sentence_transformers_utils import SENTENCE_TRANSFORMERS_TASKS
+
         inputs = data.pop("inputs", data)
         parameters = data.pop("parameters", {})
 


### PR DESCRIPTION
A gap I left in #138. `handler.py` imported `SENTENCE_TRANSFORMERS_TASKS` at module level, and `sentence_transformers_utils` imports sentence-transformers eagerly when it's installed. `webservice_starlette` imports `handler`, so every worker pulled the library — and through it torch and transformers — as part of starting up.

Measured by importing the app:

| | RSS after import | heavy modules in `sys.modules` |
|---|---|---|
| `main` (a6ddfff) | **374 MiB** | `sentence_transformers`, `torch`, `transformers` |
| this PR | **38 MiB** | none |

~336 MiB per worker, paid before a single request arrives.

That undercuts two separate things #138 set up, for different reasons:

- **`WORKERS`** multiplies the baseline — N worker processes each carrying it, resident on the node.
- **Idle unloading** is meant to hand the memory back when a worker goes quiet. It can't, if the library is resident from import regardless of whether the worker has ever served anything.

The fix is to import the constant in `_timed_call`, where it's used. #138 deliberately kept `heavy_utils` out of the import graph for exactly this reason and I missed this one; `api-inference-mini-fork` has it inside the method, with the comment *"import as late as possible to reduce the footprint"*.

## How it was found

By diffing `main` against the fork — the fork's comment showed up as something I'd dropped — and then confirmed by reading the import chain. It was **not** measured until after the fact; the numbers above came second. Worth saying because the same class of regression is invisible to the test suite, which imports modules directly and never looks at what startup drags in.

## Tests

`tests/unit`: 163 passed / 13 skipped, 3 failures identical to `main`'s in this environment (`diffusers` and `google-cloud-storage` not installed) — baselined on `main` with the same interpreter. Installing sentence-transformers locally also means the ST paths through the touched method now actually execute rather than being skipped, which is how I'd want this change covered.

`ruff check src` clean.