### PR TITLE
feat(compat): serve a named pipeline per request via /pipeline/{task}

### DIFF
--- a/src/huggingface_inference_toolkit/env_utils.py
+++ b/src/huggingface_inference_toolkit/env_utils.py
@@ -40,3 +40,20 @@ def ignore_custom_handler() -> bool:
     default pipeline instead.
     """
     return strtobool(os.getenv("IGNORE_CUSTOM_HANDLER", "false"))
+
+
+def task_route_enabled() -> bool:
+    """
+    Whether to expose /pipeline/{task}, letting a caller name the pipeline to serve a request with.
+
+    Defaults to api_inference_compat(): the Inference API needs the route, so defaulting to it means
+    adopting this code takes no deployment change. It is a separate variable because the two are
+    orthogonal — one picks a pipeline, the other reshapes responses — and because the route lets a
+    caller cause a pipeline to be built per task, each with its own copy of the weights, so it is
+    worth being able to say no to independently.
+
+    Set ENABLE_TASK_ROUTE to have the route without the compat response shapes, or to keep it off
+    while they are on.
+    """
+    value = os.getenv("ENABLE_TASK_ROUTE")
+    return api_inference_compat() if value is None else strtobool(value)

--- a/src/huggingface_inference_toolkit/webservice_starlette.py
+++ b/src/huggingface_inference_toolkit/webservice_starlette.py
@@ -21,6 +21,7 @@ from huggingface_inference_toolkit.const import (
     HF_REVISION,
     HF_TASK,
 )
+from huggingface_inference_toolkit.env_utils import task_route_enabled
 from huggingface_inference_toolkit.handler import (
     get_inference_handler_either_custom_or_default_handler,
 )
@@ -34,8 +35,8 @@ from huggingface_inference_toolkit.utils import (
 )
 from huggingface_inference_toolkit.vertex_ai_utils import _load_repository_from_gcs
 
-INFERENCE_HANDLER = None
-INFERENCE_HANDLER_SEMAPHORE = Semaphore(1)
+INFERENCE_HANDLERS = {}
+INFERENCE_HANDLERS_SEMAPHORE = Semaphore(1)
 MODEL_DOWNLOADED = False
 MODEL_DL_SEMAPHORE = Semaphore(1)
 
@@ -83,18 +84,42 @@ async def ensure_model_downloaded():
                 await async_call(download_model)
 
 
-async def ensure_handler_loaded():
-    """Load the model on first use, once, even if several requests race for it."""
-    global INFERENCE_HANDLER
-    if INFERENCE_HANDLER is None:
-        async with INFERENCE_HANDLER_SEMAPHORE:
-            if INFERENCE_HANDLER is None:
-                logger.info(f"Initializing model from directory:{HF_MODEL_DIR}")
-                INFERENCE_HANDLER = await get_inference_handler_either_custom_or_default_handler(
-                    HF_MODEL_DIR, task=HF_TASK
+def resolve_task(requested_task):
+    """
+    The task to serve a request with.
+
+    A repository serves one model, but not always through one pipeline: the sentence-transformers
+    tasks all answer `feature-extraction` requests with embeddings, which is what a caller asking
+    that route for such a repository means.
+    """
+    if requested_task == "feature-extraction" and HF_TASK in {
+        "sentence-similarity",
+        "sentence-embeddings",
+        "sentence-ranking",
+    }:
+        return "sentence-embeddings"
+    return requested_task
+
+
+async def ensure_handler_loaded(task):
+    """
+    Load the pipeline for `task` on first use, once, even if several requests race for it.
+
+    Handlers are kept per task rather than one per worker: the same model directory can be served
+    through more than one pipeline, and each is built on demand the first time it is asked for.
+    """
+    handler = INFERENCE_HANDLERS.get(task)
+    if handler is None:
+        async with INFERENCE_HANDLERS_SEMAPHORE:
+            handler = INFERENCE_HANDLERS.get(task)
+            if handler is None:
+                logger.info("Initializing %s from directory: %s", task, HF_MODEL_DIR)
+                handler = await get_inference_handler_either_custom_or_default_handler(
+                    HF_MODEL_DIR, task=task
                 )
+                INFERENCE_HANDLERS[task] = handler
                 logger.info("Model initialized successfully")
-    return INFERENCE_HANDLER
+    return handler
 
 
 async def prepare_model_artifacts():
@@ -105,7 +130,7 @@ async def prepare_model_artifacts():
         logger.info("Idle unloading enabled, deferring model load to the first request")
         return
     await ensure_model_downloaded()
-    await ensure_handler_loaded()
+    await ensure_handler_loaded(HF_TASK)
 
 
 @asynccontextmanager
@@ -160,15 +185,19 @@ async def predict(request):
 
 async def _predict(request):
     try:
+        # The route may name the task (/pipeline/{task}); otherwise it is the one this repository
+        # was deployed for.
+        task = resolve_task(request.path_params.get("task", HF_TASK))
+
         # With idle unloading the model is not loaded at startup, so the first request pays for it.
         # No-ops once loaded.
         await ensure_model_downloaded()
-        inference_handler = await ensure_handler_loaded()
+        inference_handler = await ensure_handler_loaded(task)
 
         # extracts content from request
         content_type = request.headers.get("content-Type", os.environ.get("DEFAULT_CONTENT_TYPE", ""))
         # try to deserialize payload
-        deserialized_body = ContentType.get_deserializer(content_type, HF_TASK).deserialize(
+        deserialized_body = ContentType.get_deserializer(content_type, task).deserialize(
             await request.body()
         )
         # checks if input schema is correct
@@ -178,7 +207,7 @@ async def _predict(request):
             )
 
         # Decode base64 audio inputs before running inference
-        if "parameters" in deserialized_body and HF_TASK in {
+        if "parameters" in deserialized_body and task in {
             "automatic-speech-recognition",
             "audio-classification",
         }:
@@ -249,14 +278,20 @@ if os.getenv("AIP_MODE", None) == "PREDICTION":
         lifespan=lifespan,
     )
 else:
+    routes = [
+        Route("/", health, methods=["GET"]),
+        Route("/health", health, methods=["GET"]),
+        Route("/", predict, methods=["POST"]),
+        Route("/predict", predict, methods=["POST"]),
+        Route("/metrics", metrics, methods=["GET"]),
+    ]
+    if task_route_enabled():
+        # Lets a caller ask this repository for a specific pipeline, which is how the Inference API
+        # addresses a model that serves more than one task. Opt-in: each task asked for builds its
+        # own pipeline, with its own copy of the weights, kept for the life of the worker.
+        routes.append(Route("/pipeline/{task:path}", predict, methods=["POST"]))
     app = Starlette(
         debug=False,
-        routes=[
-            Route("/", health, methods=["GET"]),
-            Route("/health", health, methods=["GET"]),
-            Route("/", predict, methods=["POST"]),
-            Route("/predict", predict, methods=["POST"]),
-            Route("/metrics", metrics, methods=["GET"]),
-        ],
+        routes=routes,
         lifespan=lifespan,
     )

--- a/tests/unit/test_multi_task.py
+++ b/tests/unit/test_multi_task.py
@@ -1,0 +1,113 @@
+from functools import partial
+
+import anyio
+import pytest
+
+from huggingface_inference_toolkit import webservice_starlette as ws
+from huggingface_inference_toolkit.env_utils import task_route_enabled
+
+
+@pytest.fixture(autouse=True)
+def empty_handler_cache(monkeypatch):
+    monkeypatch.setattr(ws, "INFERENCE_HANDLERS", {})
+
+
+@pytest.fixture
+def loads(monkeypatch):
+    """Record every task a handler is built for, and hand back a stand-in."""
+    built = []
+
+    async def fake_resolve(model_dir, task=None):
+        built.append(task)
+        return f"handler for {task}"
+
+    monkeypatch.setattr(ws, "get_inference_handler_either_custom_or_default_handler", fake_resolve)
+    return built
+
+
+def test_a_handler_is_built_once_per_task(loads):
+    assert anyio.run(partial(ws.ensure_handler_loaded, "text-classification")) == (
+        "handler for text-classification"
+    )
+    assert anyio.run(partial(ws.ensure_handler_loaded, "text-classification")) == (
+        "handler for text-classification"
+    )
+
+    assert loads == ["text-classification"]
+
+
+def test_each_task_gets_its_own_handler(loads):
+    anyio.run(partial(ws.ensure_handler_loaded, "text-classification"))
+    anyio.run(partial(ws.ensure_handler_loaded, "feature-extraction"))
+    anyio.run(partial(ws.ensure_handler_loaded, "text-classification"))
+
+    assert loads == ["text-classification", "feature-extraction"]
+    assert set(ws.INFERENCE_HANDLERS) == {"text-classification", "feature-extraction"}
+
+
+def test_requests_racing_for_the_same_task_load_it_once(loads):
+    async def race():
+        async with anyio.create_task_group() as tg:
+            for _ in range(5):
+                tg.start_soon(ws.ensure_handler_loaded, "text-classification")
+
+    anyio.run(race)
+
+    # the semaphore plus the second check inside it keep five callers to one load
+    assert loads == ["text-classification"]
+
+
+@pytest.mark.parametrize(
+    "hf_task,requested,expected",
+    [
+        # a sentence-transformers repository answers feature-extraction with embeddings
+        ("sentence-similarity", "feature-extraction", "sentence-embeddings"),
+        ("sentence-embeddings", "feature-extraction", "sentence-embeddings"),
+        ("sentence-ranking", "feature-extraction", "sentence-embeddings"),
+        # a transformers repository serves feature-extraction as itself
+        ("text-classification", "feature-extraction", "feature-extraction"),
+        ("feature-extraction", "feature-extraction", "feature-extraction"),
+        # anything else passes through untouched
+        ("sentence-similarity", "sentence-similarity", "sentence-similarity"),
+        ("text-classification", "token-classification", "token-classification"),
+    ],
+)
+def test_resolve_task(monkeypatch, hf_task, requested, expected):
+    monkeypatch.setattr(ws, "HF_TASK", hf_task)
+    assert ws.resolve_task(requested) == expected
+
+
+def test_the_route_registration_matches_the_flag():
+    # the app is built at import, so this asserts what the module decided rather than re-importing
+    paths = {getattr(route, "path", None) for route in ws.app.routes}
+
+    assert ("/pipeline/{task:path}" in paths) is task_route_enabled()
+
+
+@pytest.mark.parametrize(
+    "enable_task_route,compat,expected",
+    [
+        # unset: follows the compat flag, so the Inference API needs no extra configuration
+        (None, "1", True),
+        (None, "0", False),
+        (None, None, False),
+        # set: independent of compat, in both directions
+        ("1", "0", True),
+        ("0", "1", False),
+        ("true", None, True),
+    ],
+)
+def test_task_route_defaults_to_the_compat_flag(monkeypatch, enable_task_route, compat, expected):
+    for name, value in (("ENABLE_TASK_ROUTE", enable_task_route), ("API_INFERENCE_COMPAT", compat)):
+        if value is None:
+            monkeypatch.delenv(name, raising=False)
+        else:
+            monkeypatch.setenv(name, value)
+
+    assert task_route_enabled() is expected
+
+
+def test_a_meaningless_value_fails_rather_than_being_guessed(monkeypatch):
+    monkeypatch.setenv("ENABLE_TASK_ROUTE", "sometimes")
+    with pytest.raises(ValueError):
+        task_route_enabled()


### PR DESCRIPTION
The multi-task half of the fork's `API_INFERENCE_COMPAT` work, which needed #138's async loading to exist.

## What it does

A caller can ask a repository for a specific pipeline rather than only the task it was deployed for, which is how the Inference API addresses a model that serves several tasks.

The single handler per worker becomes **one per task**, built the first time that task is asked for and kept for the life of the worker. Loading goes through #138's async path, so a first request for a new task doesn't stall the worker's other connections while its pipeline is built.

`feature-extraction` maps to `sentence-embeddings` when the repository is a sentence-transformers one — those models answer that route with embeddings, which is what the caller means.

## Gating: its own flag, defaulting to compat

`ENABLE_TASK_ROUTE` controls the route, and **defaults to `API_INFERENCE_COMPAT`**.

It isn't gated on the compat flag directly, for two reasons. The concerns are orthogonal — one picks *which pipeline* serves a request, the other *reshapes responses* — so coupling them would mean nothing outside api-inference could have multi-task serving without also inheriting widget-shaped payloads.

And the route deserves to be refusable on its own, because the cache key comes from the path and **each task loads its own copy of the weights**:

```
same underlying model object shared between the two pipelines: False
```

So a caller can multiply a worker's resident memory by walking the tasks a model happens to support. That's a fine trade for api-inference and not something to switch on for everyone by default.

Defaulting to the compat flag keeps this free of deployment coordination: api-inference sets `API_INFERENCE_COMPAT` today and gets the route with no config change. Verified in each configuration against the running service:

| env | `POST /pipeline/text-classification` |
|---|---|
| *(neither)* | **404** |
| `API_INFERENCE_COMPAT=1` | **200** |
| `ENABLE_TASK_ROUTE=1` | **200** |
| `API_INFERENCE_COMPAT=1 ENABLE_TASK_ROUTE=0` | **404** |

## One behavioural detail worth noting

The resolved task now decides **how the body is deserialized** and **whether base64 audio input is decoded**; both previously keyed off `HF_TASK`.

Without the route those are the same value, so nothing changes. With it, `application/octet-stream` posted to an audio pipeline resolves as audio rather than by whatever the deployment's own task happens to be — which is what you'd want, though it does differ from the fork, which keeps `HF_TASK` there. Say if you'd rather I match the fork verbatim.

## Verified against the real service

Two pipelines over one model directory:

```
POST /                             -> text-classification
POST /pipeline/text-classification -> same handler, no second load
POST /pipeline/feature-extraction  -> embeddings, second handler built on demand

log: Initializing text-classification from directory: .../model
     Initializing feature-extraction from directory: .../model
```

## Tests

`tests/unit/test_multi_task.py`, 18 cases: a handler built once per task, separate handlers per task, **five requests racing for the same task still loading it once** (the double-check inside the semaphore), the `feature-extraction` mapping across sentence-transformers and transformers repositories, the flag's default and its independence from compat in both directions, and a meaningless value failing rather than being guessed.

`ruff check src tests` clean. `tests/unit`: 181 passed / 13 skipped, 3 failures identical to `main`'s in this environment (`diffusers`, `google-cloud-storage` not installed).

## Follow-up worth considering, not in this PR

The per-task cache is unbounded even with the flag on. One worker quietly holding four pipelines for a large model is a bad afternoon, so a cap or a task allowlist would be prudent — independent of gating, and happy to do it separately.

After this, what's left of the fork is phase 2: the transformers 5.x / torch 2.6 upgrade, then the vendored `question-answering` / `summarization` / `translation` / `text2text-generation` pipelines. Then the fork rebase as a completeness check.
