### PR TITLE
fix: report an unimportable custom handler instead of crashing on it

### DIFF
--- a/src/huggingface_inference_toolkit/utils.py
+++ b/src/huggingface_inference_toolkit/utils.py
@@ -51,6 +51,9 @@ def check_and_register_custom_pipeline_from_directory(model_dir):
     """
     Checks if a custom pipeline is available and registers it if so.
     """
+    # Bound up front: a handler file that exists but yields no import spec would otherwise leave
+    # this unset and raise UnboundLocalError on the way out, hiding the actual problem.
+    custom_pipeline = None
     # path to custom handler
     custom_module = Path(model_dir).joinpath(HF_DEFAULT_PIPELINE_NAME)
     legacy_module = Path(model_dir).joinpath("pipeline.py")
@@ -66,6 +69,8 @@ def check_and_register_custom_pipeline_from_directory(model_dir):
             spec.loader.exec_module(handler)
             # init custom handler with model_dir
             custom_pipeline = handler.EndpointHandler(model_dir)
+        else:
+            logger.warning("Found %s but could not build an import spec for it, ignoring it", custom_module)
 
     elif legacy_module.is_file():
         logger.warning(
@@ -83,9 +88,10 @@ def check_and_register_custom_pipeline_from_directory(model_dir):
             spec.loader.exec_module(pipeline)
             # init custom handler with model_dir
             custom_pipeline = pipeline.PreTrainedPipeline(model_dir)
+        else:
+            logger.warning("Found %s but could not build an import spec for it, ignoring it", legacy_module)
     else:
         logger.info(f"No custom pipeline found at {custom_module}")
-        custom_pipeline = None
     return custom_pipeline
 
 

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -1,4 +1,5 @@
 import asyncio
+import importlib.util
 import logging
 import os
 import tempfile
@@ -322,3 +323,20 @@ def test_convert_params_keeps_every_key():
         "do_sample": True,
         "prompt": "hi",
     }
+
+
+@pytest.mark.parametrize("handler_file", ["handler.py", "pipeline.py"])
+def test_an_unimportable_custom_handler_is_ignored_rather_than_crashing(monkeypatch, tmp_path, handler_file):
+    """
+    A handler file that exists but yields no import spec used to raise UnboundLocalError on the way
+    out of the function, which said nothing about the actual problem. Reachable by pointing
+    HF_DEFAULT_PIPELINE_NAME at a file Python cannot build a loader for.
+    """
+    (tmp_path / handler_file).write_text("class EndpointHandler:\n    def __init__(self, p): pass\n")
+    monkeypatch.setattr(importlib.util, "spec_from_file_location", lambda *a, **k: None)
+
+    assert check_and_register_custom_pipeline_from_directory(str(tmp_path)) is None
+
+
+def test_no_custom_handler_is_still_none(tmp_path):
+    assert check_and_register_custom_pipeline_from_directory(str(tmp_path)) is None


### PR DESCRIPTION
A backport from `api-inference-mini-fork`, found by rebasing that branch onto `main` and going through what remained — I'd missed it while porting everything else.

## The bug

`check_and_register_custom_pipeline_from_directory` only binds `custom_pipeline` in its final `else`. So when a handler file *exists* but `importlib.util.spec_from_file_location` returns `None`, the function falls through to `return custom_pipeline` with the name never assigned:

```
INFO  - Found custom pipeline at /tmp/tmpncur851s/handler.py
UnboundLocalError: local variable 'custom_pipeline' referenced before assignment
```

Reproduced on `main` before touching anything. importlib returns no spec when it can't determine a loader for the path, so this is reachable by pointing `HF_DEFAULT_PIPELINE_NAME` at a file whose extension Python doesn't recognise — a misconfiguration that deserves a message, not a traceback from a line that looks unrelated to it.

Both branches of the function have the same shape, so the legacy `pipeline.py` path had it too.

## The fix

Bind the name up front, and warn in both branches naming the file that was given up on:

```
INFO    - Found custom pipeline at /tmp/tmpmpxqodmk/handler.py
WARNING - Found /tmp/tmpmpxqodmk/handler.py but could not build an import spec for it, ignoring it
result: None
```

Serving then continues with the default pipeline, which is what a repository with an unusable handler should fall back to. Behaviour with no custom handler at all is unchanged.

## Tests

Two cases in `tests/unit/test_utils.py`, parametrised over `handler.py` and `pipeline.py`, plus one pinning the no-handler path. Confirmed they fail without the fix:

```
E   UnboundLocalError: local variable 'custom_pipeline' referenced before assignment
2 failed, 43 deselected
```

and pass with it. `ruff check src tests` clean.