### PR TITLE
perf: run the request/response codecs off the event loop

### DIFF
--- a/src/huggingface_inference_toolkit/async_utils.py
+++ b/src/huggingface_inference_toolkit/async_utils.py
@@ -1,3 +1,4 @@
+from functools import partial
 from typing import Callable, Optional, TypeVar
 
 import anyio
@@ -41,6 +42,29 @@ async def async_call(
         return await anyio.to_thread.run_sync(handler, *args, **kwargs)
 
 
+async def offload(func: Callable[P, T], *args: P.args, **kwargs: P.kwargs) -> T:
+    """
+    Run a CPU-bound codec on the threadpool rather than on the event loop.
+
+    Decoding a request body and encoding a response are not cheap at the sizes we serve: a PNG
+    body reaches PIL through `Image.convert("RGB")`, and a generated image goes back out through
+    `Image.save`, base64 and orjson. Left on the loop, a single large payload stalls everything
+    the loop owes the rest of the process:
+
+    - `/health` stops answering, so the orchestrator can decide a busy worker is a dead one.
+    - gunicorn's `--timeout` (30s by default, see `scripts/entrypoint.sh`) kills a worker that
+      has not heartbeat, which under plain uvicorn could not happen at all. A request killed
+      this way dies mid-flight.
+    - `Request.is_disconnected()` only reports a disconnect the loop has already processed, so
+      DISCARD_LEFT spots a departed caller sooner on a loop that is free to notice.
+
+    Deliberately outside `MAX_THREADS_GUARD`: that semaphore rations the model, and a codec
+    holding an inference slot would queue decoding behind inference for nothing. anyio's own
+    thread limiter still bounds how many of these run at once.
+    """
+    return await anyio.to_thread.run_sync(partial(func, *args, **kwargs))
+
+
 async def _caller_left(request: Request) -> bool:
     """
     Whether the caller of `request` has given up waiting for its answer.
@@ -59,7 +83,9 @@ async def _caller_left(request: Request) -> bool:
         loop blocked during the wait -> [False, True, True]
         loop free during the wait    -> [True,  True,  True]
 
-    Polling twice is what makes this independent of the loop's state, which we should not assume:
-    `predict` still decodes images (PIL) and audio (librosa) synchronously on the loop.
+    Polling twice is what makes this independent of the loop's state, which we should not assume.
+    `predict` now hands its codecs to `offload`, so the loop is no longer blocked by the request
+    being answered — but the threads that work runs in still hold the GIL between their own
+    native calls, and other requests are being served on the same loop.
     """
     return await request.is_disconnected() or await request.is_disconnected()

--- a/src/huggingface_inference_toolkit/webservice_starlette.py
+++ b/src/huggingface_inference_toolkit/webservice_starlette.py
@@ -12,7 +12,12 @@ from starlette.responses import PlainTextResponse, Response
 from starlette.routing import Route
 
 from huggingface_inference_toolkit import idle
-from huggingface_inference_toolkit.async_utils import MAX_CONCURRENT_THREADS, MAX_THREADS_GUARD, async_call
+from huggingface_inference_toolkit.async_utils import (
+    MAX_CONCURRENT_THREADS,
+    MAX_THREADS_GUARD,
+    async_call,
+    offload,
+)
 from huggingface_inference_toolkit.const import (
     HF_FRAMEWORK,
     HF_HUB_TOKEN,
@@ -196,10 +201,9 @@ async def _predict(request):
 
         # extracts content from request
         content_type = request.headers.get("content-Type", os.environ.get("DEFAULT_CONTENT_TYPE", ""))
-        # try to deserialize payload
-        deserialized_body = ContentType.get_deserializer(content_type, task).deserialize(
-            await request.body()
-        )
+        # try to deserialize payload, off the loop: this is where a PNG body reaches PIL
+        deserializer = ContentType.get_deserializer(content_type, task)
+        deserialized_body = await offload(deserializer.deserialize, await request.body())
         # checks if input schema is correct
         if "inputs" not in deserialized_body and "instances" not in deserialized_body:
             raise ValueError(
@@ -212,8 +216,8 @@ async def _predict(request):
             "audio-classification",
         }:
             # Be more strict on base64 decoding, the provided string should valid base64 encoded data
-            deserialized_body["inputs"] = base64.b64decode(
-                deserialized_body["inputs"], validate=True
+            deserialized_body["inputs"] = await offload(
+                base64.b64decode, deserialized_body["inputs"], validate=True
             )
 
         # check for query parameter and add them to the body
@@ -244,9 +248,10 @@ async def _predict(request):
         # An Accept header may list several types and carry parameters: resolve it to the single
         # media type we answer with, and serialize / label the response with that one.
         accept = ContentType.resolve_accept(accept)
-        # deserialized and resonds with json
-        serialized_response_body = ContentType.get_serializer(accept).serialize(
-            pred, accept
+        # serialize off the loop too: the JSON path PNG-encodes and base64s any PIL image it
+        # finds, so a generated image is encoded here even when the caller asked for JSON.
+        serialized_response_body = await offload(
+            ContentType.get_serializer(accept).serialize, pred, accept
         )
         return Response(serialized_response_body, media_type=accept)
     except Exception as e:

--- a/tests/unit/test_async_utils.py
+++ b/tests/unit/test_async_utils.py
@@ -1,8 +1,11 @@
+import base64
+import threading
 from functools import partial
 
 import anyio
+import pytest
 
-from huggingface_inference_toolkit.async_utils import async_call
+from huggingface_inference_toolkit.async_utils import MAX_THREADS_GUARD, async_call, offload
 
 
 class FakeRequest:
@@ -62,3 +65,39 @@ def test_detects_a_departed_caller_that_only_shows_on_the_second_poll():
     assert result is None
     assert calls == []
     assert request.polls == 2
+
+
+def test_offload_runs_the_codec_off_the_event_loop_thread():
+    # The whole point: the loop must stay free to answer /health and to heartbeat to gunicorn
+    # while a body is being decoded or a response encoded.
+    loop_thread = threading.get_ident()
+
+    codec_thread = anyio.run(partial(offload, threading.get_ident))
+
+    assert codec_thread != loop_thread
+
+
+def test_offload_does_not_wait_for_the_inference_slot():
+    # A codec must not queue behind the model: MAX_THREADS_GUARD rations inference only. Were
+    # offload to take it, this would deadlock rather than fail.
+    async def scenario():
+        async with MAX_THREADS_GUARD:
+            with anyio.fail_after(10):
+                return await offload(lambda: "decoded")
+
+    assert anyio.run(scenario) == "decoded"
+
+
+def test_offload_forwards_keyword_arguments():
+    # base64.b64decode(validate=True) is one of the calls predict() offloads, and anyio's
+    # run_sync takes no kwargs of its own.
+    assert anyio.run(partial(offload, base64.b64decode, b"aGk=", validate=True)) == b"hi"
+
+
+def test_offload_propagates_the_exception():
+    # predict() turns a codec failure into a 400, which it can only do if the error surfaces.
+    def undecodable():
+        raise ValueError("cannot identify image file")
+
+    with pytest.raises(ValueError, match="cannot identify image file"):
+        anyio.run(partial(offload, undecodable))


### PR DESCRIPTION
> **Deprioritised, and the original justification was wrong.** Opened arguing this protected against
> gunicorn's `--timeout 30` killing a worker mid-request. It does not: the arbiter passes the worker
> `timeout / 2`, so `UvicornWorker` heartbeats from the event loop every 15s and the kill needs >30s of
> continuous silence. The worst codec call measured below is 141ms. Inference is already offloaded via
> `anyio.to_thread.run_sync`, so the loop is free during generation too. Do not merge on that basis.

## What

`predict` hands its codec calls to a new `offload` helper instead of running them inline on the event loop:

- deserializing the request body (`Imager` → `Image.convert("RGB")`, `Jsoner` → `orjson.loads`)
- `base64.b64decode(validate=True)` for audio bodies
- serializing the response (`Imager` → `Image.save`, `Jsoner` → PNG + base64 + `orjson.dumps`)

## Measurements

Per call, one machine:

| | |
|---|---|
| decode 1024×1024 PNG | 5.3 ms |
| encode 1024×1024 PNG | 8.9 ms |
| encode 4096×4096 PNG | 141 ms |
| `orjson.dumps` 32×768 embeddings | 0.44 ms |
| `orjson.loads` small JSON body | 0.0002 ms |
| `offload` handoff (`anyio.to_thread.run_sync`) | 0.087 ms p50, 0.148 ms p95 |

Worth keeping regardless of what happens to this patch: the JSON path is not exempt from image encoding. `Jsoner.default` PNG-encodes and base64s any `PIL.Image` in the prediction, so a text-to-image endpoint pays the 8.9 ms even when the caller asked for `application/json`.

## The actual trade-off

What this buys is tail-latency fairness: a blocked loop delays every other in-flight request on the worker, and a burst of image requests stacks those blocks into a few hundred ms.

What it costs is two handoffs per request, ~175 µs. For an image workload that is noise against 5–141 ms of codec. For a small-JSON high-QPS endpoint it is a **net regression** — 175 µs added to a round trip whose codec cost is 0.4 µs.

Since `offload` sits outside `MAX_THREADS_GUARD` the handoff overlaps with other requests' inference, so throughput is unchanged and only per-request latency moves. That bounds the damage but does not make it a win for the common case.

If this is worth anything it is the narrow version: offload the image and audio codecs, leave JSON inline. As written it taxes the majority to help a minority.

## Also in here

`_caller_left`'s docstring cited the synchronous decoding as its reason for polling `is_disconnected()` twice, so it is updated. The double poll stays: the offload threads still hold the GIL between native calls, and the loop serves other requests.

## Testing

`tests/unit/test_async_utils.py` gains four cases: the codec runs on another thread, it does not wait for the inference slot (a `fail_after` rather than a hang if it ever takes `MAX_THREADS_GUARD`), keyword arguments reach it, and exceptions propagate so `predict` can still answer 400.

`pytest tests/unit` → 188 passed, 3 failed, 13 skipped. The three failures (`test_get_diffusers_pipeline`, `test_text_to_image_task`, `test__load_repository_from_gcs`) reproduce identically on unmodified `origin/main`.

CI: the one red job (Local Integration Tests – GPU) failed in fixture setup on a Hub download — `RemoteDisconnected` with a Hub Request ID, raised by `load_repository_from_hf` before any container started, mislabelled `Error starting container` by `conftest.py:152`. The CPU job ran the identical test against the identical model and passed.
