### PR TITLE
feat: install the build toolchain on demand instead of shipping it

### DIFF
--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -1,5 +1,64 @@
 #!/bin/bash
 
+# The runtime image carries no compiler: build-essential, cmake, the Python headers and, on the
+# CUDA variant, nvcc all live in the builder stage. Dropping them is most of what took the CPU
+# image from 3.1G to 0.7G and the GPU one from 6.8G to 4.4G, and the majority of model
+# repositories never needed them -- their requirements.txt resolves entirely to wheels.
+#
+# So install the toolchain on demand, and only for the repositories that turn out to need it.
+# The trigger is a wheels-only pip pass that failed, not merely the presence of a requirements.txt:
+# gating on the file existing would make the wheel-only majority pay the apt download too, while
+# gating on a failed ordinary install would first sit through a build that was doomed anyway.
+install_build_toolchain() {
+    echo "Installing a build toolchain to satisfy the requirements from source"
+    if ! apt-get update; then
+        return 1
+    fi
+
+    # Ask the interpreter rather than restating the version the Dockerfile installs: the headers
+    # have to match whichever Python /opt/venv was built on, and BASE_IMAGE is a build arg.
+    local python_version
+    python_version=$(python -c 'import sys; print("%d.%d" % sys.version_info[:2])') || return 1
+
+    local packages=(build-essential cmake pkg-config "python${python_version}-dev")
+
+    # A CUDA extension (flash-attn, deepspeed, apex, ...) needs nvcc to compile and the libcuda
+    # stub to link against. Neither is in the CUDA *runtime* base, and the stub is what
+    # LIBRARY_PATH pointed at back when this image was built on the devel one.
+    if [[ -n "${CUDA_VERSION:-}" ]]; then
+        local cuda_apt_version="${CUDA_VERSION%.*}"   # 12.1.0 -> 12.1
+        cuda_apt_version="${cuda_apt_version/./-}"    # 12.1   -> 12-1
+        packages+=("cuda-nvcc-${cuda_apt_version}" "cuda-cudart-dev-${cuda_apt_version}")
+        export CUDA_HOME=/usr/local/cuda
+        export PATH="${CUDA_HOME}/bin:${PATH}"
+        # Unset on the runtime base, where the devel one used to define it.
+        export LIBRARY_PATH="${CUDA_HOME}/lib64/stubs${LIBRARY_PATH:+:${LIBRARY_PATH}}"
+    fi
+
+    apt-get install -y --no-install-recommends "${packages[@]}"
+}
+
+install_requirements() {
+    local requirements=$1
+
+    # --only-binary is both the fast path and the probe: pip either resolves the whole set from
+    # wheels or refuses without attempting a single build, so nothing is half-installed before
+    # the retry below. A pip failure here is expected and not fatal -- read the second pass.
+    echo "Installing custom dependencies from ${requirements} (wheels only)"
+    if pip install -r "${requirements}" --no-cache-dir --only-binary :all:; then
+        return 0
+    fi
+
+    echo "Wheels alone did not satisfy ${requirements}, so something has to be built from source"
+    if ! install_build_toolchain; then
+        # Let pip run regardless: its own error names the package that cannot be satisfied, which
+        # is more useful to the repository owner than an apt failure.
+        echo "Warning: could not install a build toolchain, retrying the requirements anyway"
+    fi
+
+    pip install -r "${requirements}" --no-cache-dir
+}
+
 # Set the default port
 PORT=5000
 
@@ -37,9 +96,8 @@ if [[ ! -z "${HF_MODEL_ID}" ]]; then
         # Check if requirements.txt was downloaded successfully
         if [ -f "/tmp/requirements.txt" ]; then
             echo "requirements.txt downloaded successfully, now installing the dependencies..."
-            
-            # Install dependencies
-            pip install -r /tmp/requirements.txt --no-cache-dir
+
+            install_requirements /tmp/requirements.txt
             rm /tmp/requirements.txt
         else
             echo "${HF_MODEL_ID} with revision $revision contains a custom handler at $filename but doesn't contain a requirements.txt file, so skipping downloading and installing extra requirements from it."
@@ -53,8 +111,7 @@ fi
 if [[ ! -z "${HF_MODEL_DIR}" ]]; then
     # Check if requirements.txt exists and if so install dependencies
     if [ -f "${HF_MODEL_DIR}/requirements.txt" ]; then
-        echo "Installing custom dependencies from ${HF_MODEL_DIR}/requirements.txt"
-        pip install -r ${HF_MODEL_DIR}/requirements.txt --no-cache-dir
+        install_requirements "${HF_MODEL_DIR}/requirements.txt"
     fi
 fi
 


### PR DESCRIPTION
## What

`entrypoint.sh` installs a build toolchain at container start, but only for the model repositories whose `requirements.txt` cannot be satisfied from wheels.

## Why

The multi-stage split (#132) left the runtime image with no `build-essential`, `cmake`, Python headers, or `nvcc`. Verified in the published images:

```
inference-pytorch-{cpu,gpu}:sha-abf72e9
  nvcc gcc cc g++ cmake make ld  -> all MISSING
  Python.h                       -> MISSING
  /usr/local/cuda/lib64/stubs    -> MISSING (gpu)
  LIBRARY_PATH                   -> unset   (gpu)
```

That is most of the 3.1G→0.7G and 6.8G→4.4G win, and the majority of repositories never needed it. But `entrypoint.sh` runs `pip install -r requirements.txt` in that runtime stage, so a repository that has to compile now fails at startup where it used to build against the devel base. `flash-attn` is the loudest case; it is not limited to CUDA — any sdist with a C extension is affected.

Putting the toolchain back for everyone would undo the size win. This installs it for the repositories that need it and nobody else.

## How

Two passes. The first is `pip install --only-binary :all:`, which is both the fast path and the probe: pip either resolves the whole set from wheels or refuses **without attempting a build**, so nothing is half-installed before the retry. Only if that fails do we `apt-get install` the toolchain and rerun pip normally.

The alternative triggers are worse. Gating on "a `requirements.txt` exists" makes the wheel-only majority pay the apt download too — and most requirements are wheel-only. Gating on a failed *ordinary* install means first sitting through a build that was doomed.

The CUDA branch also restores `LIBRARY_PATH` to the stub directory. The devel base defined it, the runtime base does not, and without it a CUDA extension compiles but fails to link.

Package names are derived, not hardcoded: the Python version comes from the running interpreter (`sys.version_info`) since the headers must match whatever `/opt/venv` was built on and `BASE_IMAGE` is a build arg, and the CUDA apt suffix comes from `CUDA_VERSION` (`12.1.0` → `12-1`).

## Cost

| | download | packages |
|---|---|---|
| wheel-only requirements | **0** | 0 |
| CPU flavour, needs to build | 79.9 MB | 50 |
| GPU flavour, needs to build | 127 MB (475 MB on disk) | 54 |


## Trade-off worth arguing about before this merges

Image layers are cached **per node**; this apt install happens **per container start**. Endpoints scale from zero, so an affected endpoint pays it on every cold start rather than once per node. For a repository that compiles on every wake, a `-devel` image tag they opt into would be cheaper than this — the builder stage already exists, so publishing it is nearly free in CI. This PR is the better default; it is not the better answer for a heavy user.

It also puts apt on the startup critical path: `archive.ubuntu.com`, the NVIDIA repo, and the deadsnakes PPA (whose source lists are all still present in the image — verified). PyPI and Hub egress already work from these pods since `entrypoint.sh` uses both today, but **apt reachability from a workload-plane pod is the one thing I could not verify from a dev machine** and should be confirmed before merge.

## Testing

Run against the published `sha-abf72e9` images, not a local build.

CPU, wheel-only requirements — the fast path must not install anything:
```
Installing custom dependencies from /tmp/req-wheels.txt (wheels only)
exit=0    toolchain installs: 0    gcc: still absent (correct)
```

GPU, forced source build (`--no-binary :all:` in the requirements file, so the probe is overridden and pass 1 really does try — in production it refuses without building):
```
Installing custom dependencies from /tmp/req.txt (wheels only)
  Building wheel for ujson ... error
Wheels alone did not satisfy /tmp/req.txt, so something has to be built from source
Installing a build toolchain to satisfy the requirements from source
  Building wheel for ujson ... done
Successfully installed ujson-5.10.0
-> ujson imports: 5.10.0
```

GPU, after the install:
```
nvcc=/usr/local/cuda/bin/nvcc      gcc=/usr/bin/gcc
Python.h=/usr/include/python3.11/Python.h
libcuda stub=/usr/local/cuda/lib64/stubs/libcuda.so
LIBRARY_PATH=/usr/local/cuda/lib64/stubs
Cuda compilation tools, release 12.1, V12.1.105
```

And a real CUDA translation unit compiled and linked against the stub (`nvcc -o probe probe.cu -lcuda`, calling `cuInit`/`cuDeviceGetCount`) — which is what a `flash-attn` or `deepspeed` build needs — succeeds. With `CUDA_VERSION` empty the CUDA branch is skipped cleanly: 50 packages, no nvcc, `gcc` present.

