### PR TITLE
fix(diffusers): resolve the diffusers names when a pipeline is built, not at import

### DIFF
--- a/src/huggingface_inference_toolkit/diffusers_utils.py
+++ b/src/huggingface_inference_toolkit/diffusers_utils.py
@@ -31,17 +31,27 @@ DEFAULT_NUM_INFERENCE_STEPS = _generation_default("DEFAULT_NUM_INFERENCE_STEPS",
 DEFAULT_GUIDANCE_SCALE = _generation_default("DEFAULT_GUIDANCE_SCALE", float)
 
 
-if is_diffusers_available():
-    import torch
-    from diffusers import (
-        AutoPipelineForText2Image,
-        DPMSolverMultistepScheduler,
-        StableDiffusionPipeline,
-    )
-
-
 class IEAutoPipelineForText2Image:
     def __init__(self, model_dir: str, device: Union[str, None] = None, **kwargs):  # needs "cuda" for GPU
+        # Imported here rather than at module scope. `from diffusers import
+        # AutoPipelineForText2Image` resolves through diffusers' lazy module, which imports
+        # `diffusers.pipelines.auto_pipeline`, which imports *every* pipeline it knows about.
+        # One unimportable pipeline module then takes down whatever imported us -- and
+        # `heavy_utils` imports this module during `download_model`, so it took down worker
+        # startup for endpoints that have nothing to do with diffusers.
+        #
+        # Seen in production: a repository whose requirements.txt raised diffusers to 0.39
+        # while transformers stayed at the pinned 4.51.3, so `ideogram4` failed on the
+        # `transformers.masking_utils` it needs, and the endpoint never became ready.
+        # Resolving the names only when a text-to-image pipeline is actually being built
+        # keeps that failure with the request that asked for it.
+        import torch
+        from diffusers import (
+            AutoPipelineForText2Image,
+            DPMSolverMultistepScheduler,
+            StableDiffusionPipeline,
+        )
+
         dtype = torch.float32
         if device == "cuda":
             dtype = torch.bfloat16 if is_torch_bf16_gpu_available() else torch.float16
@@ -72,6 +82,8 @@ class IEAutoPipelineForText2Image:
         # diffusers doesn't support seed but rather the generator kwarg
         # see: https://github.com/huggingface/api-inference-community/blob/8e577e2d60957959ba02f474b2913d84a9086b82/docker_images/diffusers/app/pipelines/text_to_image.py#L172-L176
         if "seed" in kwargs:
+            import torch
+
             seed = int(kwargs["seed"])
             generator = torch.Generator().manual_seed(seed)
             kwargs["generator"] = generator

--- a/tests/unit/test_diffusers.py
+++ b/tests/unit/test_diffusers.py
@@ -1,10 +1,12 @@
 import logging
+import os
 import pathlib
 import subprocess
 import sys
 import tempfile
 import textwrap
 
+import huggingface_inference_toolkit
 from PIL import Image
 from transformers.testing_utils import require_torch, slow
 
@@ -95,11 +97,18 @@ def test_importing_diffusers_utils_does_not_resolve_diffusers():
         print("OK")
         """
     )
+    # Point the child at wherever the package we are testing actually lives, rather than at a
+    # path derived from this file: CI copies the tests to /opt/hf-inference-toolkit-tests and
+    # installs the package into the venv, so `__file__`-relative guessing lands on /opt/src.
+    package_root = str(pathlib.Path(huggingface_inference_toolkit.__file__).resolve().parents[1])
+    env = dict(os.environ)
+    env["PYTHONPATH"] = os.pathsep.join(filter(None, [package_root, env.get("PYTHONPATH")]))
+
     result = subprocess.run(
         [sys.executable, "-c", program],
         capture_output=True,
         text=True,
-        cwd=str(pathlib.Path(__file__).resolve().parents[2] / "src"),
+        env=env,
     )
     assert result.returncode == 0, f"import broke on an unimportable diffusers:\n{result.stderr}"
     assert "OK" in result.stdout

--- a/tests/unit/test_diffusers.py
+++ b/tests/unit/test_diffusers.py
@@ -1,5 +1,9 @@
 import logging
+import pathlib
+import subprocess
+import sys
 import tempfile
+import textwrap
 
 from PIL import Image
 from transformers.testing_utils import require_torch, slow
@@ -49,3 +53,53 @@ def test_text_to_image_task():
         pipe = get_pipeline("text-to-image", storage_dir.as_posix())
         res = pipe("Lets create an embedding")
         assert isinstance(res, Image.Image)
+
+
+def test_importing_diffusers_utils_does_not_resolve_diffusers():
+    """
+    Importing this module must not touch `diffusers`.
+
+    `from diffusers import AutoPipelineForText2Image` resolves through diffusers' lazy
+    module and imports every pipeline, so a single unimportable pipeline module used to
+    take down whatever imported us -- including worker startup, since `heavy_utils`
+    imports this module during `download_model`. Run in a subprocess with a deliberately
+    broken `diffusers` in place: the import has to survive it.
+    """
+    program = textwrap.dedent(
+        """
+        import sys, types
+        from importlib.machinery import ModuleSpec
+
+        broken = types.ModuleType("diffusers")
+        broken.__spec__ = ModuleSpec("diffusers", loader=None)
+
+        def _explode(name):
+            # Dunders have to behave: torch's op registration walks sys.modules probing
+            # for __file__, and a module that raises on that breaks unrelated imports.
+            if name.startswith("__"):
+                raise AttributeError(name)
+            raise RuntimeError(
+                "Failed to import diffusers.pipelines.auto_pipeline because of the following "
+                "error: No module named 'transformers.masking_utils'"
+            )
+
+        broken.__getattr__ = _explode
+        sys.modules["diffusers"] = broken
+
+        import huggingface_inference_toolkit.diffusers_utils as d
+
+        # The names must not have been pulled in at import time ...
+        assert not hasattr(d, "AutoPipelineForText2Image"), "diffusers resolved at import"
+        # ... and the module must still be usable for everything that is not a pipeline build.
+        assert d.is_diffusers_available() is True
+        print("OK")
+        """
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", program],
+        capture_output=True,
+        text=True,
+        cwd=str(pathlib.Path(__file__).resolve().parents[2] / "src"),
+    )
+    assert result.returncode == 0, f"import broke on an unimportable diffusers:\n{result.stderr}"
+    assert "OK" in result.stdout

--- a/tests/unit/test_diffusers.py
+++ b/tests/unit/test_diffusers.py
@@ -6,10 +6,10 @@ import sys
 import tempfile
 import textwrap
 
-import huggingface_inference_toolkit
 from PIL import Image
 from transformers.testing_utils import require_torch, slow
 
+import huggingface_inference_toolkit
 from huggingface_inference_toolkit.diffusers_utils import IEAutoPipelineForText2Image
 from huggingface_inference_toolkit.heavy_utils import get_pipeline, load_repository_from_hf
 


### PR DESCRIPTION
## What

Moved `from diffusers import AutoPipelineForText2Image, DPMSolverMultistepScheduler, StableDiffusionPipeline` (and `torch`) out of `diffusers_utils`' module scope and into `IEAutoPipelineForText2Image.__init__`, where a pipeline is actually built.

## Why

That import resolves through diffusers' lazy module, so it imports `diffusers.pipelines.auto_pipeline`, which imports **every** pipeline diffusers knows about. A single unimportable pipeline module therefore takes down whatever imported `diffusers_utils` — and `heavy_utils` imports it from `download_model`, so that is *worker startup*, for **every** endpoint, including ones with nothing to do with diffusers.

Found while watching a production rollout on 2026-08-03. A repository's `requirements.txt` raised `diffusers` to 0.39 but left `transformers` at the image's pinned 4.51.3. diffusers 0.39's `ideogram4` pipeline needs `transformers.masking_utils`, absent in 4.51.3:

```
File "/app/huggingface_inference_toolkit/diffusers_utils.py", line 36, in <module>
    from diffusers import (
RuntimeError: Failed to import diffusers.pipelines.auto_pipeline because of the following error:
  Failed to import diffusers.pipelines.ideogram4.pipeline_ideogram4 because of the following error:
    No module named 'transformers.masking_utils'
Application startup failed. Exiting.
[ERROR] Worker (pid:60) exited with code 3.
[ERROR] Reason: Worker failed to boot.
```

The endpoint never became ready. It was a text-to-image repository, so it would have gone on to build a pipeline anyway — but it would have failed *there*, with the request that asked for it, instead of preventing the worker from booting. And a repository doing anything else would not have failed at all.

**Not a regression from any recent change.** The module-scope block is byte-identical back through `sha-2d4f7f1`; I diffed it. It just became easier to hit, because the image pins a transformers old enough for a current diffusers to outrun.

## Doesn't this trade fail-fast for fail-late?

No, and it is worth being explicit because it is the obvious objection.

**Almost nothing that imports this module needs a diffusers pipeline.** `heavy_utils` imports `diffusers_utils` at module scope and is itself imported from `download_model()`, which runs for every endpoint — but `get_diffusers_pipeline` is reached from exactly one branch, `is_diffusers_available() and task == "text-to-image"`. Measured on the live default-engine population:

| | |
|---|---|
| live endpoints | 337 |
| `text-to-image`, i.e. would build a diffusers pipeline | **8** |
| everything else, importing it for nothing | **329 (98%)** |

Of that 329: 132 `custom`, 87 `text-classification`, 24 `sentence-embeddings`, 19 `token-classification`, 14 `image-classification`, 9 `automatic-speech-recognition`. And `custom` cannot reach the pipeline even in principle — `get_inference_handler_either_custom_or_default_handler` returns the custom pipeline before `HuggingFaceHandler.create`, so `get_pipeline` is never called. **The endpoint that this was found on had `HF_TASK=custom`**: it was killed at startup by an import for a code path it could not execute.

**For the endpoints that do need diffusers, the failure stays at startup.** With `UNLOAD_IDLE` unset — the default — `prepare_model_artifacts()` calls `ensure_handler_loaded(HF_TASK)` inside the lifespan, so `IEAutoPipelineForText2Image.__init__` runs during startup and a broken diffusers still stops the worker before it serves anything. It just reports as "failed building the text-to-image pipeline" rather than "failed importing a utils module". The only configuration where it becomes a first-request failure is `UNLOAD_IDLE=true`, which defers all model loading to the first request by design.

## How

The three names and `torch` are imported in `__init__`; `__call__`'s seed branch imports `torch` where it uses it. `is_diffusers_available()` keeps its meaning and stays cheap — it is `importlib.util.find_spec`, which does not execute the package. Everything else in the module (`DIFFUSERS_TASKS`, `get_diffusers_pipeline`, the generation defaults) is unaffected.

This follows the pattern already used in `webservice_starlette.download_model`, which defers `heavy_utils` for the same reason ("imported late: pulling in the hub client drags transformers with it").

## Testing

New `test_importing_diffusers_utils_does_not_resolve_diffusers` installs a deliberately broken `diffusers` in `sys.modules` — one whose `__getattr__` raises the production `RuntimeError` — and asserts in a subprocess that importing `diffusers_utils` still succeeds, that the names were not pulled in, and that `is_diffusers_available()` still answers. It **fails on `main`** and passes here, so it pins the actual regression rather than just exercising the new code.

One wrinkle worth knowing if you touch that fixture: the fake module must raise `AttributeError` for dunders. torch's custom-op registration walks `sys.modules` probing for `__file__`, and a module that raises on that breaks unrelated imports — which is how the first version of this test failed for the wrong reason.

`pytest tests/unit` → 185 passed, 3 failed, 13 skipped. The three failures (`test_get_diffusers_pipeline`, `test_text_to_image_task`, `test__load_repository_from_gcs`) are environmental — `diffusers` is not installed in my venv, so the fixture repo cannot be recognised — and reproduce identically with this commit reverted.

