### PR TITLE
fix: treat string media inputs as base64-encoded content

### DIFF
--- a/src/huggingface_inference_toolkit/serialization/base.py
+++ b/src/huggingface_inference_toolkit/serialization/base.py
@@ -1,8 +1,56 @@
+import base64
+import binascii
 from typing import Optional
 
 from huggingface_inference_toolkit.serialization.audio_utils import Audioer
 from huggingface_inference_toolkit.serialization.image_utils import Imager
 from huggingface_inference_toolkit.serialization.json_utils import Jsoner
+
+# Tasks whose top-level `inputs` is a single media item. For these, a JSON string is the media
+# content itself, base64-encoded — never a path or URL for the server to resolve. See
+# `decode_media_string_input`.
+AUDIO_INPUT_TASKS = frozenset(
+    {
+        "automatic-speech-recognition",
+        "audio-classification",
+        "zero-shot-audio-classification",
+    }
+)
+IMAGE_INPUT_TASKS = frozenset(
+    {
+        "image-classification",
+        "image-segmentation",
+        "image-to-text",
+        "image-to-image",
+        "object-detection",
+        "depth-estimation",
+        "image-feature-extraction",
+        "mask-generation",
+        "zero-shot-image-classification",
+        "zero-shot-object-detection",
+        # First positional argument is the image, so a bare string is resolved here too. The
+        # dict form these three usually arrive in is handled by `MEDIA_INPUT_KEYS` below.
+        "visual-question-answering",
+        "document-question-answering",
+        "image-text-to-text",
+    }
+)
+
+# Tasks whose `inputs` is a dict carrying the media under a key instead of being the media. The
+# handler splats such a dict into the pipeline as keyword arguments, so the nested string never
+# passes through the single-value path above and has to be decoded here as well.
+MEDIA_INPUT_KEYS = {
+    "visual-question-answering": ("image",),
+    "document-question-answering": ("image",),
+    # Only the plain `images` / `image` argument. A conversational payload nests images inside a
+    # messages list; hf-inference does not serve that shape, so it is deliberately not walked.
+    "image-text-to-text": ("images", "image"),
+}
+
+# Media tasks the toolkit registers no media type for: nothing in `content_type_mapping` can carry
+# a video, so there is no encoding a caller could legitimately send instead. transformers would
+# fetch an `http(s)` string and open anything else as a local file, so a string is refused.
+UNSUPPORTED_MEDIA_TASKS = frozenset({"video-classification"})
 
 content_type_mapping = {
     "application/json": Jsoner,
@@ -102,3 +150,72 @@ class ContentType:
     @staticmethod
     def get_serializer(accept: str):
         return _normalized_mapping[ContentType.resolve_accept(accept)]
+
+
+def _decode_base64_media(task: Optional[str], deserializer, value: str, where: str):
+    """Decode one base64 media string, or reject it. `where` names the field for the error."""
+    contract = (
+        f"{where} for task '{task}' must be the media content itself: either raw bytes sent with "
+        "a matching audio/* or image/* Content-Type, or a base64-encoded string in a JSON body."
+    )
+    try:
+        raw = base64.b64decode(value, validate=True)
+    except (binascii.Error, ValueError) as e:
+        raise ValueError(f"{contract} The provided string could not be decoded as base64 ({e}).") from e
+    try:
+        return deserializer.deserialize(raw)["inputs"]
+    except Exception as e:
+        # Decoding succeeding does not mean the caller sent media: a path is often valid base64 in
+        # its own right, `/var/lib/nonexistent` being one. Restate the contract rather than
+        # surfacing a deserializer complaint about a buffer the caller never knowingly sent.
+        raise ValueError(f"{contract} The decoded bytes are not valid media ({e}).") from e
+
+
+def decode_media_string_input(task: Optional[str], value):
+    """
+    Resolve a JSON `inputs` for a media task into the decoded media the pipeline expects.
+
+    For audio and image tasks a string input is the media content itself, base64-encoded, and is
+    decoded here into the bytes / PIL image the binary-body path already produces. This is
+    deliberately the only way a string reaches such a pipeline: passed through untouched, the
+    pipeline would resolve it as a local path or a remote reference rather than as content. A
+    string that is not valid base64 is rejected rather than passed through.
+
+    Three shapes are handled, because transformers resolves a string in all three:
+
+    - `inputs` is the media (`IMAGE_INPUT_TASKS` / `AUDIO_INPUT_TASKS`), decoded in place;
+    - `inputs` is a dict carrying the media under a key (`MEDIA_INPUT_KEYS`) -- the handler splats
+      it into the pipeline as keyword arguments, so each media key is decoded and the rest of the
+      dict is left alone;
+    - the task has no media type the toolkit can accept (`UNSUPPORTED_MEDIA_TASKS`), so a string
+      cannot be anything but a path or a URL and is refused outright.
+
+    Anything else is returned unchanged: a binary body is already decoded, and a text task's
+    string is literal text.
+    """
+    if isinstance(value, str) and task in UNSUPPORTED_MEDIA_TASKS:
+        raise ValueError(
+            f"'inputs' for task '{task}' cannot be a string: transformers would fetch it as a URL "
+            "or open it as a local file, and the toolkit registers no media type this task's "
+            "content could be sent as instead."
+        )
+
+    if isinstance(value, dict):
+        keys = MEDIA_INPUT_KEYS.get(task or "")
+        if not keys:
+            return value
+        decoded = dict(value)
+        for key in keys:
+            if isinstance(decoded.get(key), str):
+                decoded[key] = _decode_base64_media(task, Imager, decoded[key], f"'inputs[\"{key}\"]'")
+        return decoded
+
+    if not isinstance(value, str):
+        return value
+    if task in AUDIO_INPUT_TASKS:
+        deserializer = Audioer
+    elif task in IMAGE_INPUT_TASKS:
+        deserializer = Imager
+    else:
+        return value
+    return _decode_base64_media(task, deserializer, value, "'inputs'")

--- a/src/huggingface_inference_toolkit/webservice_starlette.py
+++ b/src/huggingface_inference_toolkit/webservice_starlette.py
@@ -1,5 +1,4 @@
 import asyncio
-import base64
 import os
 from contextlib import asynccontextmanager
 from pathlib import Path
@@ -27,7 +26,7 @@ from huggingface_inference_toolkit.handler import (
 )
 from huggingface_inference_toolkit.latency_guard import latency_guard
 from huggingface_inference_toolkit.logging import logger
-from huggingface_inference_toolkit.serialization.base import ContentType
+from huggingface_inference_toolkit.serialization.base import ContentType, decode_media_string_input
 from huggingface_inference_toolkit.serialization.json_utils import Jsoner
 from huggingface_inference_toolkit.utils import (
     convert_params_to_int_or_bool,
@@ -206,14 +205,14 @@ async def _predict(request):
                 f"Body needs to provide a inputs key, received: {orjson.dumps(deserialized_body)}"
             )
 
-        # Decode base64 audio inputs before running inference
-        if "parameters" in deserialized_body and task in {
-            "automatic-speech-recognition",
-            "audio-classification",
-        }:
-            # Be more strict on base64 decoding, the provided string should valid base64 encoded data
-            deserialized_body["inputs"] = base64.b64decode(
-                deserialized_body["inputs"], validate=True
+        # Media for a media task is base64-encoded content, decoded here into the bytes / PIL
+        # image the binary-body path produces -- whether `inputs` is the media itself or a dict
+        # carrying it under a key. Never let such a string reach the pipeline as-is: transformers
+        # would open it as a local file path or fetch it as a URL (arbitrary file read /
+        # server-side request forgery).
+        if "inputs" in deserialized_body:
+            deserialized_body["inputs"] = decode_media_string_input(
+                task, deserialized_body["inputs"]
             )
 
         # check for query parameter and add them to the body

--- a/tests/unit/test_serialization.py
+++ b/tests/unit/test_serialization.py
@@ -1,10 +1,15 @@
+import base64
 from io import BytesIO
 
 import pytest
 from PIL import Image
 
 from huggingface_inference_toolkit.serialization.audio_utils import Audioer
-from huggingface_inference_toolkit.serialization.base import ContentType, content_type_mapping
+from huggingface_inference_toolkit.serialization.base import (
+    ContentType,
+    content_type_mapping,
+    decode_media_string_input,
+)
 from huggingface_inference_toolkit.serialization.image_utils import MEDIA_TYPE_TO_PIL_FORMAT, Imager
 from huggingface_inference_toolkit.serialization.json_utils import Jsoner
 
@@ -154,3 +159,131 @@ def test_every_advertised_image_type_can_be_serialized():
     # would only fail at response time, on the accept path
     advertised = {media_type for media_type in content_type_mapping if media_type.startswith("image/")}
     assert advertised == set(MEDIA_TYPE_TO_PIL_FORMAT)
+
+
+def test_decode_media_string_input_decodes_base64_audio():
+    audio_bytes = b"\x00\x01RIFFfake-audio"
+    decoded = decode_media_string_input(
+        "automatic-speech-recognition", base64.b64encode(audio_bytes).decode()
+    )
+    # Decoded to the raw bytes the pipeline reads, never opened as a path
+    assert decoded == audio_bytes
+
+
+def test_decode_media_string_input_decodes_base64_image():
+    buffer = BytesIO()
+    Image.new("RGB", (8, 8), "red").save(buffer, format="PNG")
+    decoded = decode_media_string_input(
+        "image-classification", base64.b64encode(buffer.getvalue()).decode()
+    )
+    assert isinstance(decoded, Image.Image)
+    assert decoded.size == (8, 8)
+
+
+@pytest.mark.parametrize("task", ["text-classification", "text-generation", "feature-extraction"])
+def test_decode_media_string_input_leaves_text_tasks_untouched(task):
+    # A string is literal text for these tasks, not encoded media
+    assert decode_media_string_input(task, "/etc/passwd") == "/etc/passwd"
+
+
+def test_decode_media_string_input_leaves_non_strings_untouched():
+    # A binary body is already decoded to bytes / a PIL image before it reaches here
+    image = Image.new("RGB", (8, 8))
+    assert decode_media_string_input("image-classification", image) is image
+    assert decode_media_string_input("automatic-speech-recognition", b"raw-bytes") == b"raw-bytes"
+
+
+@pytest.mark.parametrize(
+    "task",
+    ["automatic-speech-recognition", "audio-classification", "image-classification", "image-to-text"],
+)
+@pytest.mark.parametrize(
+    "malicious",
+    [
+        "/tmp/plop",  # local file path
+        "http://127.0.0.1:8080/internal",  # a request the server would make on the caller's behalf
+        "https://example.com/sample.wav",
+    ],
+)
+def test_decode_media_string_input_rejects_paths_and_urls(task, malicious):
+    # A media task must never receive a raw string: transformers would open it as a file or fetch
+    # it as a URL. None of these is valid base64, so each is rejected instead of resolved.
+    with pytest.raises(ValueError, match="must be the media content itself"):
+        decode_media_string_input(task, malicious)
+
+
+@pytest.mark.parametrize("task", ["image-classification", "image-to-text"])
+def test_decode_media_string_input_rejects_a_path_that_is_itself_valid_base64(task):
+    # A path is not always rejected by the base64 decode: `/var/lib/nonexistent` is 20 characters
+    # of the base64 alphabet and decodes cleanly. What matters is that it is decoded rather than
+    # opened -- the bytes are the caller's own string, never the file -- and for an image the
+    # result is then caught as not-media, so the caller still gets the contract back.
+    #
+    # Not asserted for audio: `Audioer` hands the bytes to the pipeline as-is, since any byte
+    # string is a candidate audio payload and there is nothing to validate it against. Such a
+    # path decodes to noise and fails in the audio decoder instead, still never opened.
+    with pytest.raises(ValueError, match="must be the media content itself"):
+        decode_media_string_input(task, "/var/lib/nonexistent")
+
+
+def _b64_png():
+    buffer = BytesIO()
+    Image.new("RGB", (8, 8), "blue").save(buffer, format="PNG")
+    return base64.b64encode(buffer.getvalue()).decode()
+
+
+@pytest.mark.parametrize(
+    "task,key",
+    [
+        ("visual-question-answering", "image"),
+        ("document-question-answering", "image"),
+        ("image-text-to-text", "images"),
+        ("image-text-to-text", "image"),
+    ],
+)
+def test_decode_media_string_input_decodes_the_media_key_of_a_dict(task, key):
+    # These arrive as a dict, which the handler splats into the pipeline as keyword arguments, so
+    # the media is nested under a key rather than being `inputs` itself.
+    decoded = decode_media_string_input(task, {key: _b64_png(), "question": "what is this?"})
+    assert isinstance(decoded[key], Image.Image)
+    assert decoded[key].size == (8, 8)
+    # Everything that is not media is passed through as it was
+    assert decoded["question"] == "what is this?"
+
+
+@pytest.mark.parametrize(
+    "task,key",
+    [
+        ("visual-question-answering", "image"),
+        ("document-question-answering", "image"),
+        ("image-text-to-text", "images"),
+    ],
+)
+@pytest.mark.parametrize("malicious", ["/var/lib/nonexistent", "http://127.0.0.1:8080/internal"])
+def test_decode_media_string_input_rejects_paths_and_urls_nested_in_a_dict(task, key, malicious):
+    # `load_image` resolves a nested string exactly as it resolves a top-level one
+    with pytest.raises(ValueError, match="must be the media content itself"):
+        decode_media_string_input(task, {key: malicious, "question": "what is this?"})
+
+
+def test_decode_media_string_input_leaves_non_media_dicts_untouched():
+    # question-answering takes a dict too, but none of its values is media
+    inputs = {"question": "who?", "context": "/etc/passwd is a path, read as literal text here"}
+    assert decode_media_string_input("question-answering", inputs) == inputs
+
+
+def test_decode_media_string_input_leaves_absent_and_non_string_media_keys_untouched():
+    image = Image.new("RGB", (8, 8))
+    assert decode_media_string_input("visual-question-answering", {"question": "who?"}) == {
+        "question": "who?"
+    }
+    # A binary body is already a PIL image by the time it gets here
+    assert decode_media_string_input("visual-question-answering", {"image": image})["image"] is image
+
+
+@pytest.mark.parametrize("value", ["/var/lib/nonexistent", "http://127.0.0.1:8080/internal", "Zm9v"])
+def test_decode_media_string_input_refuses_a_string_for_video_classification(value):
+    # No media type in `content_type_mapping` can carry a video, so there is no encoding a caller
+    # could legitimately send: a string can only be something for the server to open or fetch.
+    with pytest.raises(ValueError, match="cannot be a string"):
+        decode_media_string_input("video-classification", value)


### PR DESCRIPTION
Interprets a string `inputs` for audio and image tasks as base64-encoded media content, decoded into the same bytes / PIL image the binary-body path already produces, consistently across the single-media audio and image tasks.

- `decode_media_string_input(task, value)` in `serialization/base.py` centralizes the decoding and the set of single-media audio/image tasks (reusing `Audioer` / `Imager`).
- `webservice_starlette.py` calls it for any `inputs` present, replacing the previous audio-only block that only ran when a `parameters` key happened to be present. This also lets base64 content be sent in `inputs` without a `parameters` key.
- A string that is not valid base64 is rejected with a 400.

Adds unit tests in `tests/unit/test_serialization.py` covering audio/image decoding, pass-through for text tasks and non-string inputs, and rejection of non-base64 strings.

_Description intentionally brief; will expand once merged._