### PR TITLE
fix: add the tokenizer backends transformers imports lazily

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,6 +10,17 @@
 kenlm@ git+https://github.com/kpu/kenlm@ba83eafdce6553addd885ed3da461bb0d60f8df7
 transformers[sklearn,sentencepiece,audio,vision]==4.51.3
 huggingface_hub[hf_transfer]==0.30.2
+# Tokenizer backends transformers imports lazily: when one is absent the image still builds and
+# the model raises at request time instead.
+# BertJapaneseTokenizer, with both dictionaries: mecab_dic defaults to ipadic, and the v2/v3
+# Japanese BERT checkpoints ask for unidic_lite.
+fugashi
+ipadic
+unidic-lite
+# XLMTokenizer / FlaubertTokenizer / HerbertTokenizer
+sacremoses
+# RoFormerTokenizer
+rjieba
 # vision
 Pillow
 librosa


### PR DESCRIPTION
`transformers` imports these tokenizer backends lazily, so a missing one is not a build failure:
the image builds fine and the model raises `You need to install <x>` at request time instead.

- `fugashi` + `ipadic` + `unidic-lite` — `BertJapaneseTokenizer`. Both dictionaries are needed:
  `mecab_dic` defaults to `ipadic`, while the v2/v3 Japanese BERT checkpoints set
  `mecab_dic: unidic_lite`.
- `sacremoses` — `XLMTokenizer`, `FlaubertTokenizer`, `HerbertTokenizer`.
- `rjieba` — `RoFormerTokenizer`.

Independent of the dependency migration in #109 — nothing here needs transformers 5. It does touch
the lines #109 rewrites, so whichever lands second needs a one-line rebase. 

Not built locally, so leaning on CI for the image build.