### PR TITLE
chore(docker): drop libprotobuf23 from the runtime stage

### DIFF
--- a/dockerfiles/pytorch/Dockerfile
+++ b/dockerfiles/pytorch/Dockerfile
@@ -69,7 +69,6 @@ RUN apt-get update && \
       git-lfs \
       tar \
       libsndfile1 \
-      libprotobuf23 \
       libgomp1 \
       ffmpeg \
     && apt-get clean autoremove --yes \


### PR DESCRIPTION
Nothing in the image links `libprotobuf`. Verified against a built CPU image (`integration-test-pytorch:cpu`, from the current fork branch):

- **0 of 344** shared objects under `/opt/venv` reference it
- **0** binaries or libraries elsewhere in the image reference it (`/usr/bin/*`, `/usr/lib/x86_64-linux-gnu/*.so*`)
- **no installed package** declares it as a dependency

So it is in the image only because this line names it, and dropping the line drops the library.

The Python side carries its own: the venv resolves `protobuf` (7.36.1) and `sentencepiece` (0.2.2) as manylinux wheels, both bundling their runtime. The system package is protobuf `3.12.4`, seven majors behind what is actually imported.

## Why it is worth removing

The 2.9 MB is not the point. This was the only **jammy-specific pin** in the runtime stage — the soname package is `libprotobuf23` on 22.04 and `libprotobuf32t64` on 24.04 — so it would fail any attempt to move the base image forward. With it gone, the CUDA base is the only thing fixing the distro, and that constrains the GPU variant alone (`nvidia/cuda:12.1.0` publishes no 24.04 tag; the first CUDA that does is 12.6.1).

## Left alone deliberately

The builder stage keeps `libprotobuf-dev` and `protobuf-compiler`. They are likely vestigial too, but they live in the stage that gets discarded, so they cost build time rather than image size, and ruling them out needs a full rebuild rather than an inspection.